### PR TITLE
NDEV-3839. Send update_account only for changed accounts 

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -85,6 +85,7 @@ solana-nohash-hasher = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rayon-threadlimit = { workspace = true }
 solana-rent = { workspace = true, optional = true }
+solana-sdk-ids = { workspace = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true, optional = true }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -17,7 +17,7 @@ use {
         self as address_lookup_table, error::AddressLookupError, state::AddressLookupTable,
     },
     solana_clock::{BankId, Slot},
-    solana_message::v0::LoadedAddresses,
+    solana_message::{inner_instruction::InnerInstructionsList, v0::LoadedAddresses},
     solana_pubkey::Pubkey,
     solana_slot_hashes::SlotHashes,
     solana_svm_transaction::{
@@ -554,10 +554,12 @@ impl Accounts {
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
+        inner_instructions: Option<&'a [&'a InnerInstructionsList]>,
     ) {
         self.accounts_db.store_accounts_unfrozen(
             accounts,
             transactions,
+            inner_instructions,
             UpdateIndexThreadSelection::Inline,
         );
     }
@@ -574,6 +576,7 @@ impl Accounts {
         self.accounts_db.store_accounts_unfrozen(
             accounts,
             transactions,
+            None,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -72,6 +72,7 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{measure::Measure, measure_us},
+    solana_message::inner_instruction::InnerInstructionsList,
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
     solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
@@ -5803,6 +5804,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a>,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
+        inner_instructions: Option<&'a [&'a InnerInstructionsList]>,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         // If all transactions in a batch are errored,
@@ -5822,7 +5824,12 @@ impl AccountsDb {
 
         // Store the accounts in the write cache
         let mut store_accounts_time = Measure::start("store_accounts");
-        let infos = self.write_accounts_to_cache(accounts.target_slot(), &accounts, transactions);
+        let infos = self.write_accounts_to_cache(
+            accounts.target_slot(),
+            &accounts,
+            transactions,
+            inner_instructions,
+        );
         store_accounts_time.stop();
         self.stats
             .store_accounts
@@ -5972,6 +5979,7 @@ impl AccountsDb {
         slot: Slot,
         accounts_and_meta_to_store: &impl StorableAccounts<'b>,
         txs: Option<&[&SanitizedTransaction]>,
+        inner_instructions: Option<&[&InnerInstructionsList]>,
     ) -> Vec<AccountInfo> {
         let mut current_write_version = if self.accounts_update_notifier.is_some() {
             self.write_version
@@ -5983,6 +5991,10 @@ impl AccountsDb {
         (0..accounts_and_meta_to_store.len())
             .map(|index| {
                 let txn = txs.map(|txs| *txs.get(index).expect("txs must be present if provided"));
+                let inner_instr = inner_instructions.map(|ii| {
+                    *ii.get(index)
+                        .expect("inner_instructions must be present if provided")
+                });
                 accounts_and_meta_to_store.account_default_if_zero_lamport(index, |account| {
                     let account_shared_data = account.take_account();
                     let pubkey = account.pubkey();
@@ -5995,6 +6007,7 @@ impl AccountsDb {
                         &txn,
                         pubkey,
                         current_write_version,
+                        &inner_instr,
                     );
                     current_write_version = current_write_version.saturating_add(1);
 
@@ -7317,6 +7330,7 @@ impl AccountsDb {
     pub fn store_for_tests<'a>(&self, accounts: impl StorableAccounts<'a>) {
         self.store_accounts_unfrozen(
             accounts,
+            None,
             None,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -4,6 +4,7 @@ use {
     solana_clock::Slot,
     solana_message::inner_instruction::InnerInstructionsList,
     solana_pubkey::Pubkey,
+    solana_sdk_ids::sysvar as sysvar_program,
     solana_system_interface::program as system_program,
     solana_transaction::sanitized::SanitizedTransaction,
 };
@@ -13,13 +14,8 @@ use {
 /// - Sysvars cannot be mutated (checked by base58 prefix)
 /// - System program can modify any account's lamports
 /// - Other programs can only modify accounts they own
-fn can_runtime_mutate_account(
-    invoked_program_id: &Pubkey,
-    account_owner: &Pubkey,
-    account_pubkey: &Pubkey,
-) -> bool {
-    let pubkey_str = account_pubkey.to_string();
-    if pubkey_str.starts_with("Sysvar") {
+fn can_runtime_mutate_account(invoked_program_id: &Pubkey, account_owner: &Pubkey) -> bool {
+    if sysvar_program::check_id(account_owner) {
         return false;
     }
 
@@ -81,7 +77,7 @@ fn should_notify_account_to_geyser(
             continue;
         }
 
-        if can_runtime_mutate_account(program_id, account.owner(), pubkey) {
+        if can_runtime_mutate_account(program_id, account.owner()) {
             return true;
         }
     }
@@ -101,7 +97,7 @@ fn should_notify_account_to_geyser(
 
             let prog_idx = ix.instruction.program_id_index as usize;
             if let Some(program_id) = account_keys.get(prog_idx) {
-                if can_runtime_mutate_account(program_id, account.owner(), pubkey) {
+                if can_runtime_mutate_account(program_id, account.owner()) {
                     return true;
                 }
             }

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -2,6 +2,7 @@ use {
     crate::accounts_db::AccountsDb,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
+    solana_message::inner_instruction::InnerInstructionsList,
     solana_pubkey::Pubkey,
     solana_system_interface::program as system_program,
     solana_transaction::sanitized::SanitizedTransaction,
@@ -35,12 +36,14 @@ fn can_runtime_mutate_account(
 /// Optimized to check account mutability with early exits:
 /// - Fee payer (index 0) is always mutable
 /// - Only writable accounts are checked
-/// - Only instructions that touch the account are examined
+/// - Top-level instructions that touch the account are examined
+/// - Inner instructions (CPIs) that touch the account are also examined
 /// - Ownership rules determine if program can mutate the account
 fn should_notify_account_to_geyser(
     txn: &Option<&SanitizedTransaction>,
     account: &AccountSharedData,
     pubkey: &Pubkey,
+    inner_instructions: &Option<&InnerInstructionsList>,
 ) -> bool {
     let Some(txn) = txn else {
         return true;
@@ -63,6 +66,11 @@ fn should_notify_account_to_geyser(
         return true;
     }
 
+    let Some(inner_instructions) = inner_instructions else {
+        return true;
+    };
+
+    // Check top-level instructions
     for (program_id, instruction) in message.program_instructions_iter() {
         let touches_account = instruction
             .accounts
@@ -78,6 +86,28 @@ fn should_notify_account_to_geyser(
         }
     }
 
+    // Check inner instructions (CPIs)
+    for instruction_list in inner_instructions.iter() {
+        for ix in instruction_list {
+            let touches_account = ix
+                .instruction
+                .accounts
+                .iter()
+                .any(|&idx| idx as usize == account_index);
+
+            if !touches_account {
+                continue;
+            }
+
+            let prog_idx = ix.instruction.program_id_index as usize;
+            if let Some(program_id) = account_keys.get(prog_idx) {
+                if can_runtime_mutate_account(program_id, account.owner(), pubkey) {
+                    return true;
+                }
+            }
+        }
+    }
+
     false
 }
 
@@ -89,10 +119,11 @@ impl AccountsDb {
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
         write_version: u64,
+        inner_instructions: &Option<&InnerInstructionsList>,
     ) {
         if let Some(accounts_update_notifier) = &self.accounts_update_notifier {
             // Filter accounts based on whether they can actually be mutated by the transaction
-            if should_notify_account_to_geyser(txn, account, pubkey) {
+            if should_notify_account_to_geyser(txn, account, pubkey, inner_instructions) {
                 accounts_update_notifier.notify_account_update(
                     slot,
                     account,
@@ -117,7 +148,6 @@ pub mod tests {
             utils::create_account_shared_data,
         },
         dashmap::DashMap,
-        solana_account::ReadableAccount as _,
         std::sync::{
             atomic::{AtomicBool, Ordering},
             Arc,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -1,7 +1,85 @@
 use {
-    crate::accounts_db::AccountsDb, solana_account::AccountSharedData, solana_clock::Slot,
-    solana_pubkey::Pubkey, solana_transaction::sanitized::SanitizedTransaction,
+    crate::accounts_db::AccountsDb,
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_clock::Slot,
+    solana_pubkey::Pubkey,
+    solana_system_interface::program as system_program,
+    solana_transaction::sanitized::SanitizedTransaction,
 };
+
+/// Determines if an account can be mutated by a program during transaction execution.
+/// This implements Solana's runtime rules for account mutability:
+/// - Sysvars cannot be mutated (checked by base58 prefix)
+/// - System program can modify any account's lamports
+/// - Other programs can only modify accounts they own
+fn can_runtime_mutate_account(
+    invoked_program_id: &Pubkey,
+    account_owner: &Pubkey,
+    account_pubkey: &Pubkey,
+) -> bool {
+    let pubkey_str = account_pubkey.to_string();
+    if pubkey_str.starts_with("Sysvar") {
+        return false;
+    }
+
+    if system_program::check_id(invoked_program_id) {
+        return true;
+    }
+
+    account_owner == invoked_program_id
+}
+
+/// Determines whether an account should be notified to Geyser plugins.
+/// Returns true if the account can actually be mutated by the transaction.
+///
+/// Optimized to check account mutability with early exits:
+/// - Fee payer (index 0) is always mutable
+/// - Only writable accounts are checked
+/// - Only instructions that touch the account are examined
+/// - Ownership rules determine if program can mutate the account
+fn should_notify_account_to_geyser(
+    txn: &Option<&SanitizedTransaction>,
+    account: &AccountSharedData,
+    pubkey: &Pubkey,
+) -> bool {
+    let Some(txn) = txn else {
+        return true;
+    };
+
+    let message = txn.message();
+    let account_keys = message.account_keys();
+
+    let account_index = account_keys.iter().position(|key| key == pubkey);
+    let Some(account_index) = account_index else {
+        // Account not in transaction - shouldn't happen, but notify to be safe
+        return true;
+    };
+
+    if !message.is_writable(account_index) {
+        return false;
+    }
+
+    if account_index == 0 {
+        return true;
+    }
+
+    for (program_id, instruction) in message.program_instructions_iter() {
+        let touches_account = instruction
+            .accounts
+            .iter()
+            .any(|&idx| idx as usize == account_index);
+
+        if !touches_account {
+            continue;
+        }
+
+        if can_runtime_mutate_account(program_id, account.owner(), pubkey) {
+            return true;
+        }
+    }
+
+    false
+}
 
 impl AccountsDb {
     pub fn notify_account_at_accounts_update(
@@ -13,13 +91,16 @@ impl AccountsDb {
         write_version: u64,
     ) {
         if let Some(accounts_update_notifier) = &self.accounts_update_notifier {
-            accounts_update_notifier.notify_account_update(
-                slot,
-                account,
-                txn,
-                pubkey,
-                write_version,
-            );
+            // Filter accounts based on whether they can actually be mutated by the transaction
+            if should_notify_account_to_geyser(txn, account, pubkey) {
+                accounts_update_notifier.notify_account_update(
+                    slot,
+                    account,
+                    txn,
+                    pubkey,
+                    write_version,
+                );
+            }
         }
     }
 }

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,6 +1,7 @@
 use {
     core::borrow::Borrow,
     solana_account::AccountSharedData,
+    solana_message::inner_instruction::InnerInstructionsList,
     solana_pubkey::Pubkey,
     solana_svm::{
         rollback_accounts::RollbackAccounts,
@@ -55,10 +56,14 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
 ) -> (
     Vec<(&'a Pubkey, &'a AccountSharedData)>,
     Option<Vec<&'a SanitizedTransaction>>,
+    Option<Vec<&'a InnerInstructionsList>>,
 ) {
     let collect_capacity = max_number_of_accounts_to_collect(txs, processing_results);
     let mut accounts = Vec::with_capacity(collect_capacity);
     let mut transactions = txs_refs
+        .is_some()
+        .then(|| Vec::with_capacity(collect_capacity));
+    let mut inner_instructions = txs_refs
         .is_some()
         .then(|| Vec::with_capacity(collect_capacity));
     for (index, (processing_result, transaction)) in processing_results.iter().zip(txs).enumerate()
@@ -75,14 +80,17 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                     collect_accounts_for_successful_tx(
                         &mut accounts,
                         &mut transactions,
+                        &mut inner_instructions,
                         transaction,
                         transaction_ref,
                         &executed_tx.loaded_transaction.accounts,
+                        &executed_tx.execution_details.inner_instructions,
                     );
                 } else {
                     collect_accounts_for_failed_tx(
                         &mut accounts,
                         &mut transactions,
+                        &mut inner_instructions,
                         transaction_ref,
                         &executed_tx.loaded_transaction.rollback_accounts,
                     );
@@ -92,21 +100,24 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                 collect_accounts_for_failed_tx(
                     &mut accounts,
                     &mut transactions,
+                    &mut inner_instructions,
                     transaction_ref,
                     &fees_only_tx.rollback_accounts,
                 );
             }
         }
     }
-    (accounts, transactions)
+    (accounts, transactions, inner_instructions)
 }
 
 fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
+    collected_inner_instructions: &mut Option<Vec<&'a InnerInstructionsList>>,
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [KeyedAccountSharedData],
+    inner_instructions: &'a Option<InnerInstructionsList>,
 ) {
     for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {
@@ -126,12 +137,22 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
             collected_account_transactions
                 .push(transaction_ref.expect("transaction ref must exist if collecting"));
         }
+        if let Some(collected_inner_instructions) = collected_inner_instructions {
+            // Use static empty vec for None case to avoid temporary value
+            static EMPTY_INNER_INSTRUCTIONS: InnerInstructionsList = Vec::new();
+
+            let inner_instr = inner_instructions
+                .as_ref()
+                .unwrap_or(&EMPTY_INNER_INSTRUCTIONS);
+            collected_inner_instructions.push(inner_instr);
+        }
     }
 }
 
 fn collect_accounts_for_failed_tx<'a>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
+    collected_inner_instructions: &mut Option<Vec<&'a InnerInstructionsList>>,
     transaction_ref: Option<&'a SanitizedTransaction>,
     rollback_accounts: &'a RollbackAccounts,
 ) {
@@ -140,6 +161,13 @@ fn collect_accounts_for_failed_tx<'a>(
         if let Some(collected_account_transactions) = collected_account_transactions {
             collected_account_transactions
                 .push(transaction_ref.expect("transaction ref must exist if collecting"));
+        }
+        if let Some(collected_inner_instructions) = collected_inner_instructions {
+            // Default empty inner instructions for failed transactions
+            static EMPTY_INNER_INSTRUCTIONS: InnerInstructionsList = Vec::new();
+
+            // Failed transactions don't have inner instructions
+            collected_inner_instructions.push(&EMPTY_INNER_INSTRUCTIONS);
         }
     }
 }
@@ -271,7 +299,7 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) =
+            let (collected_accounts, transactions, _) =
                 collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 2);
             assert!(collected_accounts
@@ -335,7 +363,7 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) =
+            let (collected_accounts, transactions, _) =
                 collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(
@@ -427,7 +455,7 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) =
+            let (collected_accounts, transactions, _) =
                 collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 2);
             assert_eq!(
@@ -532,7 +560,7 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) =
+            let (collected_accounts, transactions, _) =
                 collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             let collected_nonce_account = collected_accounts
@@ -588,7 +616,7 @@ mod tests {
 
         for collect_transactions in [false, true] {
             let transaction_refs = collect_transactions.then(|| txs.iter().collect::<Vec<_>>());
-            let (collected_accounts, transactions) =
+            let (collected_accounts, transactions, _) =
                 collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
             assert_eq!(collected_accounts.len(), 1);
             assert_eq!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3640,7 +3640,7 @@ impl Bank {
                         .collect::<Vec<_>>()
                 });
 
-            let (accounts_to_store, transactions) = collect_accounts_to_store(
+            let (accounts_to_store, transactions, inner_instructions) = collect_accounts_to_store(
                 sanitized_txs,
                 &maybe_transaction_refs,
                 &processing_results,
@@ -3650,9 +3650,11 @@ impl Bank {
             self.update_bank_hash_stats(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
-            self.rc
-                .accounts
-                .store_accounts_seq(to_store, transactions.as_deref());
+            self.rc.accounts.store_accounts_seq(
+                to_store,
+                transactions.as_deref(),
+                inner_instructions.as_deref(),
+            );
         });
 
         // Cached vote and stake accounts are synchronized with accounts-db

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -221,7 +221,7 @@ mod serde_snapshot_tests {
             .collect();
         for (i, pubkey) in pubkeys.iter().enumerate() {
             let account = AccountSharedData::new(i as u64 + 1, 0, &Pubkey::default());
-            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None);
+            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None, None);
         }
         check_accounts_local(&accounts, &pubkeys, 100);
         accounts.accounts_db.add_root_and_flush_write_cache(slot);


### PR DESCRIPTION
NDEV-3839. Send update_account only for changed accounts, even if the account is writable in the transaction