### PR TITLE
PRS-40, metrics draft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5505,6 +5505,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if 1.0.1",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "proptest"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,6 +5600,12 @@ dependencies = [
  "protobuf-src",
  "tonic-build",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-src"
@@ -9339,11 +9360,13 @@ dependencies = [
  "env_logger",
  "gethostname",
  "log",
+ "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.23",
  "serial_test",
  "solana-cluster-type",
  "solana-sha256-hasher",
+ "solana-signature",
  "solana-time-utils",
  "thiserror 2.0.16",
 ]

--- a/METRICS.md
+++ b/METRICS.md
@@ -1,0 +1,98 @@
+# Parasol Custom Metrics
+
+This project exposes custom node metrics via:
+
+- `GET /metrics`
+
+Typical URL:
+
+- `http://<RPC_HOST>:<RPC_PORT>/metrics`
+- Example: `http://127.0.0.1:8899/metrics`
+
+## Main Metrics
+
+### Counters
+
+- `tx_accepted_total`: transactions accepted into the node retry/acceptance pipeline (deterministic acceptance point).
+- `tx_executed_total`: committed transactions with successful execution (`status=Ok`).
+- `tx_failed_total`: committed failed transactions (`status=Err`) and failed outcomes in retry flow.
+- `tx_dropped_total`: transactions dropped before execution (ingress/scheduler/retry-pool overflow paths).
+- `tx_expired_total`: transactions dropped due to expiry (blockhash/nonce validity window).
+- `confirmation_timeout_rate`: tracked signatures that did not reach confirmation within timeout.
+- `account_lock_conflict_rate`: lock conflict occurrences (`AccountInUse`-like execution contention).
+- `retry_due_to_account_in_use_rate`: retries caused by account lock contention.
+- `fork_rate`: fork-failure signal from replay/heaviest-fork failure states.
+- `duplicate_confirmed_blocks`: duplicate-confirmed slot/hash events observed by replay logic.
+
+### Gauge
+
+- `avg_locked_accounts_per_tx`: average locked-account footprint per transaction.
+
+### Histograms
+
+- `node_ingress_latency_seconds`: RPC ingress processing latency (`t1 -> t2` proxy).
+- `mempool_acceptance_latency_seconds`: acceptance latency in send-transaction-service (`t2 -> t3`).
+- `acknowledge_latency_seconds`: end-to-end node acknowledge latency (`t1 -> t3`).
+- `decision_response_latency_seconds`: node decision response latency in current RPC path (`forwarded -> RPC return` proxy).
+- `node_to_decision_response_latency_seconds`: request-to-response latency at node side (`t1 -> response point`).
+- `time_to_processed_seconds`: signature lifecycle latency to processed commitment.
+- `time_to_confirmed_seconds`: signature lifecycle latency to confirmed commitment.
+- `time_to_finalized_seconds`: signature lifecycle latency to finalized commitment.
+- `tx_execution_in_block_latency_seconds`: latency from acceptance to processed execution in block (`t3 -> t5`, exact `t3` when available).
+- `block_production_latency_seconds`: latency from acceptance to produced/frozen block (`t3 -> t6`, exact `t3` when available).
+- `state_update_notification_latency_seconds`: pubsub notification preparation/queue/send latency (`t6 -> t7` approximation).
+- `blockhash_fetch_latency_seconds`: RPC latency for `getLatestBlockhash`.
+- `blockhash_age_at_submit_slots`: age of submitted blockhash at send time (in slots).
+- `blockhash_remaining_validity_slots`: remaining validity window of submitted blockhash (in slots).
+
+## `tx_type` Label Mapping (Config / CLI)
+
+`tx_type` can be derived by rules keyed by:
+
+- `program_id`
+- first 8 bytes of `instruction_data` (instruction discriminator)
+
+For Anchor methods, discriminator is computed as:
+
+- `sha256("global:<method_name>")[0..8]`
+
+### CLI Examples
+
+Use a config file:
+
+```bash
+agave-validator \
+  --rpc-tx-type-map-config /path/to/tx_type_rules.yaml
+```
+
+Inline rules (repeatable):
+
+```bash
+agave-validator \
+  --rpc-tx-type-map-rule <PROGRAM_ID>:place_order:place_order \
+  --rpc-tx-type-map-rule <PROGRAM_ID>:42:cancel_order \
+  --rpc-tx-type-map-rule <PROGRAM_ID>:0x0102030405060708:liquidation
+```
+
+Rule format:
+
+- `PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE`
+
+`DISCRIMINATOR_U64` is converted with `to_le_bytes()` and matched against `instruction_data[0..8]`.
+
+### Config File Example (YAML)
+
+```yaml
+rules:
+  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
+    method_name: place_order
+    tx_type: place_order
+
+  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
+    discriminator: 42
+    tx_type: cancel_order
+
+  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
+    discriminator: 0x0102030405060708
+    tx_type: liquidation
+```

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -10,6 +10,7 @@ use {
     solana_fee::FeeFeatures,
     solana_fee_structure::FeeBudgetLimits,
     solana_measure::measure_us,
+    solana_metrics::custom_metrics,
     solana_poh::{
         poh_recorder::PohRecorderError,
         transaction_recorder::{
@@ -256,6 +257,8 @@ impl Consumer {
                 // following are retryable errors
                 Err(TransactionError::AccountInUse) => {
                     error_counters.account_in_use += 1;
+                    custom_metrics::inc_account_lock_conflict_rate(1);
+                    custom_metrics::inc_retry_due_to_account_in_use_rate(1);
                     Some(index)
                 }
                 Err(TransactionError::WouldExceedMaxBlockCostLimit) => {

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -29,6 +29,7 @@ use {
     solana_cost_model::cost_model::CostModel,
     solana_fee_structure::FeeBudgetLimits,
     solana_measure::measure_us,
+    solana_metrics::custom_metrics,
     solana_message::v0::MessageAddressTableLookup,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
@@ -347,6 +348,9 @@ impl SanitizedTransactionReceiveAndBuffer {
 
                 let (priority, cost) =
                     calculate_priority_and_cost(&transaction, &fee_budget_limits, &working_bank);
+                custom_metrics::observe_avg_locked_accounts_per_tx(
+                    transaction.message().account_keys().len() as u64,
+                );
                 num_buffered += 1;
                 if container.insert_new_transaction(transaction, max_age, priority, cost) {
                     num_dropped_on_capacity += 1;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -324,6 +324,17 @@ where
                 receive_time_us: _,
                 buffer_time_us: _,
             } = &receiving_stats;
+            let total_dropped = *num_dropped_without_buffering
+                + *num_dropped_on_parsing_and_sanitization
+                + *num_dropped_on_lock_validation
+                + *num_dropped_on_compute_budget
+                + *num_dropped_on_age
+                + *num_dropped_on_already_processed
+                + *num_dropped_on_fee_payer
+                + *num_dropped_on_capacity;
+            if total_dropped > 0 {
+                solana_metrics::custom_metrics::inc_tx_dropped_total(total_dropped as u64);
+            }
 
             count_metrics.num_received += *num_received;
             count_metrics.num_dropped_on_receive += *num_dropped_without_buffering;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1897,6 +1897,7 @@ impl ReplayStage {
                     // Already processed this signal
                     continue;
                 }
+                solana_metrics::custom_metrics::inc_duplicate_confirmed_blocks(1);
 
                 let duplicate_confirmed_state = DuplicateConfirmedState::new_from_state(
                     duplicate_confirmed_hash,
@@ -4237,6 +4238,9 @@ impl ReplayStage {
         heaviest_bank: &Arc<Bank>,
         last_threshold_failure_slot: &mut Slot,
     ) {
+        if !heaviest_fork_failures.is_empty() {
+            solana_metrics::custom_metrics::inc_fork_rate(heaviest_fork_failures.len() as u64);
+        }
         info!(
             "Couldn't vote on heaviest fork: {:?}, heaviest_fork_failures: {:?}",
             heaviest_bank.slot(),

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -19,9 +19,11 @@ name = "solana_metrics"
 crossbeam-channel = { workspace = true }
 gethostname = { workspace = true }
 log = { workspace = true }
+prometheus = "0.13.4"
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-cluster-type = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-signature = { workspace = true }
 solana-time-utils = { workspace = true }
 thiserror = { workspace = true }
 

--- a/metrics/src/custom_metrics.rs
+++ b/metrics/src/custom_metrics.rs
@@ -1,0 +1,715 @@
+use {
+    prometheus::{
+        Encoder, Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts,
+        Registry, TextEncoder,
+    },
+    solana_signature::Signature,
+    std::{
+        collections::{HashMap, HashSet},
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            LazyLock, Mutex,
+        },
+        time::Instant,
+    },
+};
+
+const LATENCY_BUCKETS_US: &[u64] = &[
+    50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000,
+    1_000_000, 2_500_000, 5_000_000, 10_000_000,
+];
+const BLOCKHASH_AGE_BUCKETS_SLOTS: &[u64] = &[0, 1, 2, 4, 8, 16, 32, 64, 96, 128, 160, 192];
+const BLOCKHASH_REMAINING_VALIDITY_BUCKETS_SLOTS: &[u64] = &[
+    0, 1, 2, 4, 8, 16, 32, 64, 96, 128, 160, 192, 256, 512, 1_024, 2_048, 4_096, 8_192, 16_384,
+    32_768, 65_536, 131_072, 262_144, 524_288, 1_048_576, 2_097_152, 4_194_304,
+];
+const MAX_TX_TYPE_SERIES: usize = 32;
+
+fn latency_buckets_seconds() -> Vec<f64> {
+    LATENCY_BUCKETS_US
+        .iter()
+        .map(|value| *value as f64 / 1_000_000.0)
+        .collect()
+}
+
+fn slots_buckets(values: &[u64]) -> Vec<f64> {
+    values.iter().map(|value| *value as f64).collect()
+}
+
+fn make_counter(name: &str, help: &str) -> IntCounter {
+    IntCounter::with_opts(Opts::new(name, help)).expect("counter opts must be valid")
+}
+
+fn make_counter_vec(name: &str, help: &str) -> IntCounterVec {
+    IntCounterVec::new(Opts::new(name, help), &["tx_type"]).expect("counter vec opts must be valid")
+}
+
+fn make_latency_histogram(name: &str, help: &str) -> Histogram {
+    Histogram::with_opts(HistogramOpts::new(name, help).buckets(latency_buckets_seconds()))
+        .expect("histogram opts must be valid")
+}
+
+fn make_latency_histogram_vec(name: &str, help: &str) -> HistogramVec {
+    HistogramVec::new(
+        HistogramOpts::new(name, help).buckets(latency_buckets_seconds()),
+        &["tx_type"],
+    )
+    .expect("histogram vec opts must be valid")
+}
+
+fn make_slots_histogram(name: &str, help: &str, buckets: &[u64]) -> Histogram {
+    Histogram::with_opts(HistogramOpts::new(name, help).buckets(slots_buckets(buckets)))
+        .expect("histogram opts must be valid")
+}
+
+struct CustomMetrics {
+    registry: Registry,
+    labeled_registry: Registry,
+
+    tx_accepted_total: IntCounter,
+    tx_accepted_total_by_type: IntCounterVec,
+    tx_executed_total: IntCounter,
+    tx_executed_total_by_type: IntCounterVec,
+    tx_failed_total: IntCounter,
+    tx_failed_total_by_type: IntCounterVec,
+    tx_dropped_total: IntCounter,
+    tx_dropped_total_by_type: IntCounterVec,
+    tx_expired_total: IntCounter,
+    tx_expired_total_by_type: IntCounterVec,
+    confirmation_timeout_rate: IntCounter,
+    account_lock_conflict_rate: IntCounter,
+    retry_due_to_account_in_use_rate: IntCounter,
+    fork_rate: IntCounter,
+    duplicate_confirmed_blocks: IntCounter,
+
+    avg_locked_accounts_per_tx: Gauge,
+    locked_accounts_total: AtomicU64,
+    locked_accounts_samples: AtomicU64,
+
+    blockhash_fetch_latency: Histogram,
+    blockhash_age_at_submit_slots: Histogram,
+    blockhash_remaining_validity_slots: Histogram,
+    time_to_processed: Histogram,
+    time_to_confirmed: Histogram,
+    time_to_finalized: Histogram,
+    node_ingress_latency: Histogram,
+    node_ingress_latency_by_type: HistogramVec,
+    mempool_acceptance_latency: Histogram,
+    mempool_acceptance_latency_by_type: HistogramVec,
+    decision_response_latency: Histogram,
+    decision_response_latency_by_type: HistogramVec,
+    node_to_decision_response_latency: Histogram,
+    node_to_decision_response_latency_by_type: HistogramVec,
+    tx_execution_in_block_latency: Histogram,
+    block_production_latency: Histogram,
+    state_update_notification_latency: Histogram,
+    acknowledge_latency: Histogram,
+    acknowledge_latency_by_type: HistogramVec,
+
+    tx_type_known: Mutex<HashSet<String>>,
+}
+
+impl CustomMetrics {
+    fn new() -> Self {
+        let registry = Registry::new();
+        let labeled_registry = Registry::new();
+
+        let tx_accepted_total = make_counter(
+            "tx_accepted_total",
+            "Transactions accepted into retry/acceptance pipeline",
+        );
+        registry
+            .register(Box::new(tx_accepted_total.clone()))
+            .expect("metric registration must succeed");
+        let tx_accepted_total_by_type =
+            make_counter_vec("tx_accepted_total", "Transactions accepted by tx_type");
+        labeled_registry
+            .register(Box::new(tx_accepted_total_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let tx_executed_total = make_counter("tx_executed_total", "Successfully committed transactions");
+        registry
+            .register(Box::new(tx_executed_total.clone()))
+            .expect("metric registration must succeed");
+        let tx_executed_total_by_type =
+            make_counter_vec("tx_executed_total", "Successfully committed transactions by tx_type");
+        labeled_registry
+            .register(Box::new(tx_executed_total_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let tx_failed_total = make_counter("tx_failed_total", "Failed transactions");
+        registry
+            .register(Box::new(tx_failed_total.clone()))
+            .expect("metric registration must succeed");
+        let tx_failed_total_by_type =
+            make_counter_vec("tx_failed_total", "Failed transactions by tx_type");
+        labeled_registry
+            .register(Box::new(tx_failed_total_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let tx_dropped_total = make_counter("tx_dropped_total", "Dropped transactions");
+        registry
+            .register(Box::new(tx_dropped_total.clone()))
+            .expect("metric registration must succeed");
+        let tx_dropped_total_by_type =
+            make_counter_vec("tx_dropped_total", "Dropped transactions by tx_type");
+        labeled_registry
+            .register(Box::new(tx_dropped_total_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let tx_expired_total = make_counter("tx_expired_total", "Expired transactions");
+        registry
+            .register(Box::new(tx_expired_total.clone()))
+            .expect("metric registration must succeed");
+        let tx_expired_total_by_type =
+            make_counter_vec("tx_expired_total", "Expired transactions by tx_type");
+        labeled_registry
+            .register(Box::new(tx_expired_total_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let confirmation_timeout_rate = make_counter(
+            "confirmation_timeout_rate",
+            "Transactions that timed out before confirmation",
+        );
+        registry
+            .register(Box::new(confirmation_timeout_rate.clone()))
+            .expect("metric registration must succeed");
+
+        let account_lock_conflict_rate =
+            make_counter("account_lock_conflict_rate", "Account lock conflict occurrences");
+        registry
+            .register(Box::new(account_lock_conflict_rate.clone()))
+            .expect("metric registration must succeed");
+
+        let retry_due_to_account_in_use_rate = make_counter(
+            "retry_due_to_account_in_use_rate",
+            "Retries due to account-in-use contention",
+        );
+        registry
+            .register(Box::new(retry_due_to_account_in_use_rate.clone()))
+            .expect("metric registration must succeed");
+
+        let fork_rate = make_counter("fork_rate", "Fork failure signal");
+        registry
+            .register(Box::new(fork_rate.clone()))
+            .expect("metric registration must succeed");
+
+        let duplicate_confirmed_blocks =
+            make_counter("duplicate_confirmed_blocks", "Duplicate confirmed block events");
+        registry
+            .register(Box::new(duplicate_confirmed_blocks.clone()))
+            .expect("metric registration must succeed");
+
+        let avg_locked_accounts_per_tx =
+            Gauge::with_opts(Opts::new("avg_locked_accounts_per_tx", "Average locked accounts per transaction"))
+                .expect("gauge opts must be valid");
+        registry
+            .register(Box::new(avg_locked_accounts_per_tx.clone()))
+            .expect("metric registration must succeed");
+
+        let blockhash_fetch_latency =
+            make_latency_histogram("blockhash_fetch_latency_seconds", "Blockhash fetch latency");
+        registry
+            .register(Box::new(blockhash_fetch_latency.clone()))
+            .expect("metric registration must succeed");
+
+        let blockhash_age_at_submit_slots = make_slots_histogram(
+            "blockhash_age_at_submit_slots",
+            "Blockhash age at submit time in slots",
+            BLOCKHASH_AGE_BUCKETS_SLOTS,
+        );
+        registry
+            .register(Box::new(blockhash_age_at_submit_slots.clone()))
+            .expect("metric registration must succeed");
+
+        let blockhash_remaining_validity_slots = make_slots_histogram(
+            "blockhash_remaining_validity_slots",
+            "Remaining blockhash validity at submit time in slots",
+            BLOCKHASH_REMAINING_VALIDITY_BUCKETS_SLOTS,
+        );
+        registry
+            .register(Box::new(blockhash_remaining_validity_slots.clone()))
+            .expect("metric registration must succeed");
+
+        let time_to_processed =
+            make_latency_histogram("time_to_processed_seconds", "Time to processed commitment");
+        registry
+            .register(Box::new(time_to_processed.clone()))
+            .expect("metric registration must succeed");
+
+        let time_to_confirmed =
+            make_latency_histogram("time_to_confirmed_seconds", "Time to confirmed commitment");
+        registry
+            .register(Box::new(time_to_confirmed.clone()))
+            .expect("metric registration must succeed");
+
+        let time_to_finalized =
+            make_latency_histogram("time_to_finalized_seconds", "Time to finalized commitment");
+        registry
+            .register(Box::new(time_to_finalized.clone()))
+            .expect("metric registration must succeed");
+
+        let node_ingress_latency =
+            make_latency_histogram("node_ingress_latency_seconds", "Node ingress latency");
+        registry
+            .register(Box::new(node_ingress_latency.clone()))
+            .expect("metric registration must succeed");
+        let node_ingress_latency_by_type =
+            make_latency_histogram_vec("node_ingress_latency_seconds", "Node ingress latency by tx_type");
+        labeled_registry
+            .register(Box::new(node_ingress_latency_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let mempool_acceptance_latency = make_latency_histogram(
+            "mempool_acceptance_latency_seconds",
+            "Mempool acceptance latency",
+        );
+        registry
+            .register(Box::new(mempool_acceptance_latency.clone()))
+            .expect("metric registration must succeed");
+        let mempool_acceptance_latency_by_type = make_latency_histogram_vec(
+            "mempool_acceptance_latency_seconds",
+            "Mempool acceptance latency by tx_type",
+        );
+        labeled_registry
+            .register(Box::new(mempool_acceptance_latency_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let decision_response_latency = make_latency_histogram(
+            "decision_response_latency_seconds",
+            "Decision response latency",
+        );
+        registry
+            .register(Box::new(decision_response_latency.clone()))
+            .expect("metric registration must succeed");
+        let decision_response_latency_by_type = make_latency_histogram_vec(
+            "decision_response_latency_seconds",
+            "Decision response latency by tx_type",
+        );
+        labeled_registry
+            .register(Box::new(decision_response_latency_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let node_to_decision_response_latency = make_latency_histogram(
+            "node_to_decision_response_latency_seconds",
+            "Node to decision response latency",
+        );
+        registry
+            .register(Box::new(node_to_decision_response_latency.clone()))
+            .expect("metric registration must succeed");
+        let node_to_decision_response_latency_by_type = make_latency_histogram_vec(
+            "node_to_decision_response_latency_seconds",
+            "Node to decision response latency by tx_type",
+        );
+        labeled_registry
+            .register(Box::new(node_to_decision_response_latency_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        let tx_execution_in_block_latency = make_latency_histogram(
+            "tx_execution_in_block_latency_seconds",
+            "Execution in block latency",
+        );
+        registry
+            .register(Box::new(tx_execution_in_block_latency.clone()))
+            .expect("metric registration must succeed");
+
+        let block_production_latency = make_latency_histogram(
+            "block_production_latency_seconds",
+            "Block production latency",
+        );
+        registry
+            .register(Box::new(block_production_latency.clone()))
+            .expect("metric registration must succeed");
+
+        let state_update_notification_latency = make_latency_histogram(
+            "state_update_notification_latency_seconds",
+            "State update notification latency",
+        );
+        registry
+            .register(Box::new(state_update_notification_latency.clone()))
+            .expect("metric registration must succeed");
+
+        let acknowledge_latency =
+            make_latency_histogram("acknowledge_latency_seconds", "Acknowledge latency");
+        registry
+            .register(Box::new(acknowledge_latency.clone()))
+            .expect("metric registration must succeed");
+        let acknowledge_latency_by_type =
+            make_latency_histogram_vec("acknowledge_latency_seconds", "Acknowledge latency by tx_type");
+        labeled_registry
+            .register(Box::new(acknowledge_latency_by_type.clone()))
+            .expect("metric registration must succeed");
+
+        Self {
+            registry,
+            labeled_registry,
+            tx_accepted_total,
+            tx_accepted_total_by_type,
+            tx_executed_total,
+            tx_executed_total_by_type,
+            tx_failed_total,
+            tx_failed_total_by_type,
+            tx_dropped_total,
+            tx_dropped_total_by_type,
+            tx_expired_total,
+            tx_expired_total_by_type,
+            confirmation_timeout_rate,
+            account_lock_conflict_rate,
+            retry_due_to_account_in_use_rate,
+            fork_rate,
+            duplicate_confirmed_blocks,
+            avg_locked_accounts_per_tx,
+            locked_accounts_total: AtomicU64::new(0),
+            locked_accounts_samples: AtomicU64::new(0),
+            blockhash_fetch_latency,
+            blockhash_age_at_submit_slots,
+            blockhash_remaining_validity_slots,
+            time_to_processed,
+            time_to_confirmed,
+            time_to_finalized,
+            node_ingress_latency,
+            node_ingress_latency_by_type,
+            mempool_acceptance_latency,
+            mempool_acceptance_latency_by_type,
+            decision_response_latency,
+            decision_response_latency_by_type,
+            node_to_decision_response_latency,
+            node_to_decision_response_latency_by_type,
+            tx_execution_in_block_latency,
+            block_production_latency,
+            state_update_notification_latency,
+            acknowledge_latency,
+            acknowledge_latency_by_type,
+            tx_type_known: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn bounded_tx_type(&self, tx_type: &str) -> String {
+        let tx_type = normalize_tx_type(tx_type);
+        let mut known = self.tx_type_known.lock().unwrap();
+        if known.contains(&tx_type) {
+            return tx_type;
+        }
+        if known.len() < MAX_TX_TYPE_SERIES {
+            known.insert(tx_type.clone());
+            return tx_type;
+        }
+        known.insert("other".to_string());
+        "other".to_string()
+    }
+}
+
+fn normalize_tx_type(tx_type: &str) -> String {
+    if tx_type.is_empty() {
+        return "unknown".to_string();
+    }
+    let normalized = tx_type
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | '0'..='9' | '_' => ch,
+            'A'..='Z' => ch.to_ascii_lowercase(),
+            '-' | ' ' | ':' | '/' => '_',
+            _ => '_',
+        })
+        .collect::<String>();
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized.chars().take(48).collect::<String>()
+    }
+}
+
+static CUSTOM_METRICS: LazyLock<CustomMetrics> = LazyLock::new(CustomMetrics::new);
+static TX_ACCEPTANCE_TIMES: LazyLock<Mutex<HashMap<Signature, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub fn register_tx_acceptance_time(signature: Signature, accepted_at: Instant) {
+    if let Ok(mut values) = TX_ACCEPTANCE_TIMES.lock() {
+        values.insert(signature, accepted_at);
+    }
+}
+
+pub fn get_tx_acceptance_time(signature: &Signature) -> Option<Instant> {
+    TX_ACCEPTANCE_TIMES
+        .lock()
+        .ok()
+        .and_then(|values| values.get(signature).copied())
+}
+
+pub fn clear_tx_acceptance_time(signature: &Signature) {
+    if let Ok(mut values) = TX_ACCEPTANCE_TIMES.lock() {
+        values.remove(signature);
+    }
+}
+
+pub fn inc_tx_accepted_total(value: u64) {
+    CUSTOM_METRICS.tx_accepted_total.inc_by(value);
+}
+
+pub fn inc_tx_accepted_total_with_type(value: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .tx_accepted_total_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .inc_by(value);
+}
+
+pub fn inc_tx_executed_total(value: u64) {
+    CUSTOM_METRICS.tx_executed_total.inc_by(value);
+}
+
+pub fn inc_tx_executed_total_with_type(value: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .tx_executed_total_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .inc_by(value);
+}
+
+pub fn inc_tx_failed_total(value: u64) {
+    CUSTOM_METRICS.tx_failed_total.inc_by(value);
+}
+
+pub fn inc_tx_failed_total_with_type(value: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .tx_failed_total_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .inc_by(value);
+}
+
+pub fn inc_tx_dropped_total(value: u64) {
+    CUSTOM_METRICS.tx_dropped_total.inc_by(value);
+}
+
+pub fn inc_tx_dropped_total_with_type(value: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .tx_dropped_total_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .inc_by(value);
+}
+
+pub fn inc_tx_expired_total(value: u64) {
+    CUSTOM_METRICS.tx_expired_total.inc_by(value);
+}
+
+pub fn inc_tx_expired_total_with_type(value: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .tx_expired_total_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .inc_by(value);
+}
+
+pub fn inc_confirmation_timeout_rate(value: u64) {
+    CUSTOM_METRICS.confirmation_timeout_rate.inc_by(value);
+}
+
+pub fn inc_account_lock_conflict_rate(value: u64) {
+    CUSTOM_METRICS.account_lock_conflict_rate.inc_by(value);
+}
+
+pub fn inc_retry_due_to_account_in_use_rate(value: u64) {
+    CUSTOM_METRICS.retry_due_to_account_in_use_rate.inc_by(value);
+}
+
+pub fn inc_fork_rate(value: u64) {
+    CUSTOM_METRICS.fork_rate.inc_by(value);
+}
+
+pub fn inc_duplicate_confirmed_blocks(value: u64) {
+    CUSTOM_METRICS.duplicate_confirmed_blocks.inc_by(value);
+}
+
+pub fn observe_avg_locked_accounts_per_tx(locked_accounts: u64) {
+    CUSTOM_METRICS
+        .locked_accounts_total
+        .fetch_add(locked_accounts, Ordering::Relaxed);
+    let samples = CUSTOM_METRICS
+        .locked_accounts_samples
+        .fetch_add(1, Ordering::Relaxed)
+        + 1;
+    let total = CUSTOM_METRICS.locked_accounts_total.load(Ordering::Relaxed);
+    let avg = if samples == 0 {
+        0.0
+    } else {
+        total as f64 / samples as f64
+    };
+    CUSTOM_METRICS.avg_locked_accounts_per_tx.set(avg);
+}
+
+pub fn observe_blockhash_fetch_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .blockhash_fetch_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_blockhash_age_at_submit_slots(value_slots: u64) {
+    CUSTOM_METRICS
+        .blockhash_age_at_submit_slots
+        .observe(value_slots as f64);
+}
+
+pub fn observe_blockhash_remaining_validity_slots(value_slots: u64) {
+    CUSTOM_METRICS
+        .blockhash_remaining_validity_slots
+        .observe(value_slots as f64);
+}
+
+pub fn observe_time_to_processed_us(value_us: u64) {
+    CUSTOM_METRICS
+        .time_to_processed
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_time_to_confirmed_us(value_us: u64) {
+    CUSTOM_METRICS
+        .time_to_confirmed
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_time_to_finalized_us(value_us: u64) {
+    CUSTOM_METRICS
+        .time_to_finalized
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_node_ingress_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .node_ingress_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_node_ingress_latency_us_with_type(value_us: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .node_ingress_latency_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_mempool_acceptance_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .mempool_acceptance_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_mempool_acceptance_latency_us_with_type(value_us: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .mempool_acceptance_latency_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_decision_response_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .decision_response_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_decision_response_latency_us_with_type(value_us: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .decision_response_latency_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_node_to_decision_response_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .node_to_decision_response_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_node_to_decision_response_latency_us_with_type(value_us: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .node_to_decision_response_latency_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_tx_execution_in_block_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .tx_execution_in_block_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_block_production_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .block_production_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_state_update_notification_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .state_update_notification_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_acknowledge_latency_us(value_us: u64) {
+    CUSTOM_METRICS
+        .acknowledge_latency
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn observe_acknowledge_latency_us_with_type(value_us: u64, tx_type: &str) {
+    let tx_type = CUSTOM_METRICS.bounded_tx_type(tx_type);
+    CUSTOM_METRICS
+        .acknowledge_latency_by_type
+        .with_label_values(&[tx_type.as_str()])
+        .observe(value_us as f64 / 1_000_000.0);
+}
+
+pub fn render_prometheus() -> String {
+    let encoder = TextEncoder::new();
+
+    let mut out = Vec::new();
+    encoder
+        .encode(&CUSTOM_METRICS.registry.gather(), &mut out)
+        .expect("prometheus encoding must succeed");
+
+    let mut labeled_out = Vec::new();
+    encoder
+        .encode(&CUSTOM_METRICS.labeled_registry.gather(), &mut labeled_out)
+        .expect("prometheus encoding must succeed");
+
+    let out_text = String::from_utf8(out).expect("prometheus text must be valid utf-8");
+    let labeled_text =
+        String::from_utf8(labeled_out).expect("prometheus text must be valid utf-8");
+
+    let mut seen_meta = HashSet::new();
+    for line in out_text.lines() {
+        if let Some(name) = line
+            .strip_prefix("# HELP ")
+            .or_else(|| line.strip_prefix("# TYPE "))
+            .and_then(|meta| meta.split_whitespace().next())
+        {
+            seen_meta.insert(name.to_string());
+        }
+    }
+
+    let mut merged = out_text;
+    if !merged.is_empty() && !labeled_text.is_empty() && !merged.ends_with('\n') {
+        merged.push('\n');
+    }
+    for line in labeled_text.lines() {
+        let maybe_meta_name = line
+            .strip_prefix("# HELP ")
+            .or_else(|| line.strip_prefix("# TYPE "))
+            .and_then(|meta| meta.split_whitespace().next());
+        if let Some(name) = maybe_meta_name {
+            if seen_meta.contains(name) {
+                continue;
+            }
+            seen_meta.insert(name.to_string());
+        }
+        merged.push_str(line);
+        merged.push('\n');
+    }
+
+    merged
+}

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod counter;
+pub mod custom_metrics;
 pub mod datapoint;
 pub mod metrics;
 pub use crate::metrics::{flush, query, set_host_id, set_panic_hook, submit};

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4573,6 +4573,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.2",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4625,6 +4640,12 @@ checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-src"
@@ -7324,9 +7345,11 @@ dependencies = [
  "crossbeam-channel",
  "gethostname",
  "log",
+ "prometheus",
  "reqwest 0.12.23",
  "solana-cluster-type",
  "solana-sha256-hasher",
+ "solana-signature",
  "solana-time-utils",
  "thiserror 2.0.16",
 ]
@@ -7896,6 +7919,7 @@ dependencies = [
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-send-transaction-service",
+ "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
  "solana-slot-history",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -75,6 +75,7 @@ solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-send-transaction-service = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-slot-history = { workspace = true }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -13,9 +13,11 @@ pub mod rpc_pubsub_service;
 pub mod rpc_service;
 pub mod rpc_subscription_tracker;
 pub mod rpc_subscriptions;
+pub mod signature_metrics_tracker;
 pub mod slot_status_notifier;
 pub mod transaction_notifier_interface;
 pub mod transaction_status_service;
+pub mod tx_type_rules;
 
 #[macro_use]
 extern crate log;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use {
         filter::filter_allows, max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
+        signature_metrics_tracker, tx_type_rules,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     bincode::{config::Options, serialize},
@@ -46,7 +47,7 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_message::{AddressLoader, SanitizedMessage},
-    solana_metrics::inc_new_counter_info,
+    solana_metrics::{custom_metrics, inc_new_counter_info},
     solana_perf::packet::PACKET_DATA_SIZE,
     solana_program_pack::Pack,
     solana_pubkey::{Pubkey, PUBKEY_BYTES},
@@ -115,7 +116,7 @@ use {
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, RwLock,
         },
-        time::Duration,
+        time::{Duration, Instant},
     },
     tokio::runtime::Runtime,
 };
@@ -175,6 +176,7 @@ pub struct JsonRpcConfig {
     pub full_api: bool,
     pub rpc_scan_and_fix_roots: bool,
     pub max_request_body_size: Option<usize>,
+    pub tx_type_rules: Vec<tx_type_rules::RpcTxTypeRule>,
     /// Disable the health check, used for tests and TestValidator
     pub disable_health_check: bool,
 }
@@ -196,6 +198,7 @@ impl Default for JsonRpcConfig {
             full_api: Default::default(),
             rpc_scan_and_fix_roots: Default::default(),
             max_request_body_size: Option::default(),
+            tx_type_rules: Vec::default(),
             disable_health_check: Default::default(),
         }
     }
@@ -419,6 +422,7 @@ impl JsonRpcRequestProcessor {
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         runtime: Arc<Runtime>,
     ) -> (Self, Receiver<TransactionInfo>) {
+        tx_type_rules::set_rules(config.tx_type_rules.clone());
         let (transaction_sender, transaction_receiver) = unbounded();
         (
             Self {
@@ -2695,8 +2699,12 @@ fn _send_transaction(
     last_valid_block_height: u64,
     durable_nonce_info: Option<(Pubkey, Hash)>,
     max_retries: Option<usize>,
+    received_at: Instant,
+    forwarded_at: Instant,
+    tx_type: String,
 ) -> Result<String> {
-    let transaction_info = TransactionInfo::new(
+    signature_metrics_tracker::register_signature(signature, received_at, forwarded_at);
+    let transaction_info = TransactionInfo::new_with_timing(
         message_hash,
         signature,
         blockhash,
@@ -2704,8 +2712,11 @@ fn _send_transaction(
         last_valid_block_height,
         durable_nonce_info,
         max_retries,
+        received_at,
+        forwarded_at,
         None,
-    );
+    )
+    .with_tx_type(tx_type);
     meta.transaction_sender
         .send(transaction_info)
         .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {err}"));
@@ -3752,6 +3763,8 @@ pub mod rpc_full {
             lamports: u64,
             config: Option<RpcRequestAirdropConfig>,
         ) -> Result<String> {
+            let received_at = Instant::now();
+            let tx_type = "airdrop".to_string();
             debug!("request_airdrop rpc request received");
             trace!(
                 "request_airdrop id={} lamports={} config: {:?}",
@@ -3771,9 +3784,15 @@ pub mod rpc_full {
             } else {
                 bank.confirmed_last_blockhash()
             };
+            if let Some(blockhash_age_slots) = bank.get_hash_age(&blockhash) {
+                custom_metrics::observe_blockhash_age_at_submit_slots(blockhash_age_slots);
+            }
             let last_valid_block_height = bank
                 .get_blockhash_last_valid_block_height(&blockhash)
                 .unwrap_or(0);
+            custom_metrics::observe_blockhash_remaining_validity_slots(
+                last_valid_block_height.saturating_sub(bank.block_height()),
+            );
 
             let transaction =
                 request_airdrop_transaction(&faucet_addr, &pubkey, lamports, blockhash).map_err(
@@ -3795,7 +3814,19 @@ pub mod rpc_full {
                 return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
             };
 
-            _send_transaction(
+            let forwarded_at = Instant::now();
+            custom_metrics::observe_node_ingress_latency_us(
+                forwarded_at
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+            );
+            custom_metrics::observe_node_ingress_latency_us_with_type(
+                forwarded_at
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+                &tx_type,
+            );
+            let result = _send_transaction(
                 meta,
                 message_hash,
                 signature,
@@ -3804,7 +3835,22 @@ pub mod rpc_full {
                 last_valid_block_height,
                 None,
                 None,
-            )
+                received_at,
+                forwarded_at,
+                tx_type.clone(),
+            );
+            custom_metrics::observe_node_to_decision_response_latency_us(
+                Instant::now()
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+            );
+            custom_metrics::observe_node_to_decision_response_latency_us_with_type(
+                Instant::now()
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+                &tx_type,
+            );
+            result
         }
 
         fn send_transaction(
@@ -3813,6 +3859,7 @@ pub mod rpc_full {
             data: String,
             config: Option<RpcSendTransactionConfig>,
         ) -> Result<String> {
+            let received_at = Instant::now();
             debug!("send_transaction rpc request received");
             let RpcSendTransactionConfig {
                 skip_preflight,
@@ -3845,9 +3892,16 @@ pub mod rpc_full {
                 preflight_bank,
                 preflight_bank.get_reserved_account_keys(),
             )?;
+            let tx_type = tx_type_rules::infer_from_message(
+                transaction.message(),
+                transaction.is_simple_vote_transaction(),
+            );
             let blockhash = *transaction.message().recent_blockhash();
             let message_hash = *transaction.message_hash();
             let signature = *transaction.signature();
+            if let Some(blockhash_age_slots) = preflight_bank.get_hash_age(&blockhash) {
+                custom_metrics::observe_blockhash_age_at_submit_slots(blockhash_age_slots);
+            }
 
             let mut last_valid_block_height = preflight_bank
                 .get_blockhash_last_valid_block_height(&blockhash)
@@ -3863,6 +3917,9 @@ pub mod rpc_full {
                 // retried until the nonce is advanced.
                 last_valid_block_height = preflight_bank.block_height() + MAX_PROCESSING_AGE as u64;
             }
+            custom_metrics::observe_blockhash_remaining_validity_slots(
+                last_valid_block_height.saturating_sub(preflight_bank.block_height()),
+            );
 
             if !skip_preflight {
                 verify_transaction(&transaction)?;
@@ -3933,7 +3990,19 @@ pub mod rpc_full {
                 }
             }
 
-            _send_transaction(
+            let forwarded_at = Instant::now();
+            custom_metrics::observe_node_ingress_latency_us(
+                forwarded_at
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+            );
+            custom_metrics::observe_node_ingress_latency_us_with_type(
+                forwarded_at
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+                &tx_type,
+            );
+            let result = _send_transaction(
                 meta,
                 message_hash,
                 signature,
@@ -3942,7 +4011,33 @@ pub mod rpc_full {
                 last_valid_block_height,
                 durable_nonce_info,
                 max_retries,
-            )
+                received_at,
+                forwarded_at,
+                tx_type.clone(),
+            );
+            custom_metrics::observe_node_to_decision_response_latency_us(
+                Instant::now()
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+            );
+            custom_metrics::observe_node_to_decision_response_latency_us_with_type(
+                Instant::now()
+                    .saturating_duration_since(received_at)
+                    .as_micros() as u64,
+                &tx_type,
+            );
+            custom_metrics::observe_decision_response_latency_us(
+                Instant::now()
+                    .saturating_duration_since(forwarded_at)
+                    .as_micros() as u64,
+            );
+            custom_metrics::observe_decision_response_latency_us_with_type(
+                Instant::now()
+                    .saturating_duration_since(forwarded_at)
+                    .as_micros() as u64,
+                &tx_type,
+            );
+            result
         }
 
         fn simulate_transaction(
@@ -4228,7 +4323,12 @@ pub mod rpc_full {
             config: Option<RpcContextConfig>,
         ) -> Result<RpcResponse<RpcBlockhash>> {
             debug!("get_latest_blockhash rpc request received");
-            meta.get_latest_blockhash(config.unwrap_or_default())
+            let start = Instant::now();
+            let result = meta.get_latest_blockhash(config.unwrap_or_default());
+            custom_metrics::observe_blockhash_fetch_latency_us(
+                Instant::now().saturating_duration_since(start).as_micros() as u64,
+            );
+            result
         }
 
         fn is_blockhash_valid(

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -8,6 +8,7 @@ use {
         rpc::{rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_full::*, rpc_minimal::*, *},
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
+        signature_metrics_tracker,
     },
     crossbeam_channel::unbounded,
     jsonrpc_core::{futures::prelude::*, MetaIoHandler},
@@ -27,7 +28,7 @@ use {
         bigtable_upload_service::BigTableUploadService, blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
     },
-    solana_metrics::inc_new_counter_info,
+    solana_metrics::{custom_metrics, inc_new_counter_info},
     solana_perf::thread::renice_this_thread,
     solana_poh::poh_recorder::PohRecorder,
     solana_quic_definitions::NotifyKeyUpdate,
@@ -115,6 +116,7 @@ where
 
 pub struct JsonRpcService {
     thread_hdl: JoinHandle<()>,
+    signature_metrics_sweeper_hdl: Option<JoinHandle<()>>,
 
     #[cfg(test)]
     pub request_processor: JsonRpcRequestProcessor, // Used only by test_rpc_new()...
@@ -392,6 +394,13 @@ impl RequestMiddleware for RpcRequestMiddleware {
             process_rest(&self.bank_forks, path)
         } else if self.is_file_get_path(request.uri().path()) {
             self.process_file_get(request.uri().path())
+        } else if request.uri().path() == "/metrics" {
+            hyper::Response::builder()
+                .status(hyper::StatusCode::OK)
+                .header(hyper::header::CONTENT_TYPE, "text/plain; version=0.0.4")
+                .body(hyper::Body::from(custom_metrics::render_prometheus()))
+                .unwrap()
+                .into()
         } else if request.uri().path() == "/health" {
             hyper::Response::builder()
                 .status(hyper::StatusCode::OK)
@@ -814,7 +823,7 @@ impl JsonRpcService {
             receiver,
             client.clone(),
             send_transaction_service_config,
-            exit,
+            exit.clone(),
         ));
 
         #[cfg(test)]
@@ -892,6 +901,9 @@ impl JsonRpcService {
             }));
         Ok(Self {
             thread_hdl,
+            signature_metrics_sweeper_hdl: Some(signature_metrics_tracker::start_timeout_sweeper(
+                exit.clone(),
+            )),
             #[cfg(test)]
             request_processor: test_request_processor,
             close_handle: Some(close_handle),
@@ -907,6 +919,9 @@ impl JsonRpcService {
 
     pub fn join(mut self) -> thread::Result<()> {
         self.exit();
+        if let Some(sweeper_hdl) = self.signature_metrics_sweeper_hdl.take() {
+            let _ = sweeper_hdl.join();
+        }
         self.thread_hdl.join()
     }
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -6,6 +6,7 @@ use {
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::{get_parsed_token_account, get_parsed_token_accounts},
         rpc_pubsub_service::PubSubConfig,
+        signature_metrics_tracker,
         rpc_subscription_tracker::{
             AccountSubscriptionParams, BlockSubscriptionKind, BlockSubscriptionParams,
             LogsSubscriptionKind, LogsSubscriptionParams, ProgramSubscriptionParams,
@@ -839,6 +840,12 @@ impl RpcSubscriptions {
                             }
                         }
                         NotificationEntry::Bank(commitment_slots) => {
+                            signature_metrics_tracker::mark_confirmed_up_to_slot(
+                                commitment_slots.highest_confirmed_slot,
+                            );
+                            signature_metrics_tracker::mark_finalized_up_to_slot(
+                                commitment_slots.highest_super_majority_root,
+                            );
                             const SOURCE: &str = "bank";
                             RpcSubscriptions::notify_watchers(
                                 max_complete_transaction_status_slot.clone(),
@@ -851,6 +858,7 @@ impl RpcSubscriptions {
                             );
                         }
                         NotificationEntry::Gossip(slot) => {
+                            signature_metrics_tracker::mark_confirmed_up_to_slot(slot);
                             let commitment_slots = CommitmentSlots {
                                 highest_confirmed_slot: slot,
                                 ..CommitmentSlots::default()
@@ -896,6 +904,9 @@ impl RpcSubscriptions {
                     }
                     stats.notification_entry_processing_time_us +=
                         queued_at.elapsed().as_micros() as u64;
+                    solana_metrics::custom_metrics::observe_state_update_notification_latency_us(
+                        queued_at.elapsed().as_micros() as u64,
+                    );
                     stats.notification_entry_processing_count += 1;
                 }
                 Err(RecvTimeoutError::Timeout) => {
@@ -1113,6 +1124,13 @@ impl RpcSubscriptions {
 
                         if notified {
                             num_signatures_notified.fetch_add(1, Ordering::Relaxed);
+                            if params.commitment.is_finalized() {
+                                signature_metrics_tracker::mark_finalized(&params.signature);
+                            } else if params.commitment.is_confirmed() {
+                                signature_metrics_tracker::mark_confirmed(&params.signature);
+                            } else if params.commitment.is_processed() {
+                                signature_metrics_tracker::mark_processed(&params.signature);
+                            }
                         }
                     }
                 }

--- a/rpc/src/signature_metrics_tracker.rs
+++ b/rpc/src/signature_metrics_tracker.rs
@@ -1,0 +1,276 @@
+use {
+    solana_clock::Slot,
+    solana_metrics::custom_metrics,
+    solana_signature::Signature,
+    std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, LazyLock, Mutex,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::{Duration, Instant},
+    },
+};
+
+const CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(60);
+const SWEEP_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+struct SignatureLifecycle {
+    t1: Instant,
+    t3_proxy: Instant,
+    t3_exact: Option<Instant>,
+    processed: bool,
+    confirmed: bool,
+    finalized: bool,
+    slot: Option<Slot>,
+}
+
+#[derive(Default)]
+struct SignatureMetricsTracker {
+    by_signature: HashMap<Signature, SignatureLifecycle>,
+    by_slot: HashMap<Slot, Vec<Signature>>,
+    last_sweep: Option<Instant>,
+}
+
+impl SignatureMetricsTracker {
+    fn register(&mut self, signature: Signature, t1: Instant, t3_proxy: Instant) {
+        self.by_signature.insert(
+            signature,
+            SignatureLifecycle {
+                t1,
+                t3_proxy,
+                t3_exact: None,
+                processed: false,
+                confirmed: false,
+                finalized: false,
+                slot: None,
+            },
+        );
+    }
+
+    fn effective_t3(signature: &Signature, state: &mut SignatureLifecycle) -> Instant {
+        if state.t3_exact.is_none() {
+            state.t3_exact = custom_metrics::get_tx_acceptance_time(signature);
+        }
+        state.t3_exact.unwrap_or(state.t3_proxy)
+    }
+
+    fn observe_processed_once(state: &mut SignatureLifecycle, now: Instant) {
+        if !state.processed {
+            custom_metrics::observe_time_to_processed_us(
+                now.saturating_duration_since(state.t1).as_micros() as u64,
+            );
+            state.processed = true;
+        }
+    }
+
+    fn remove_signature_from_slot(&mut self, slot: Slot, signature: &Signature) {
+        if let Some(signatures) = self.by_slot.get_mut(&slot) {
+            signatures.retain(|entry| entry != signature);
+            if signatures.is_empty() {
+                self.by_slot.remove(&slot);
+            }
+        }
+    }
+
+    fn mark_processed(&mut self, signature: &Signature, now: Instant) {
+        if let Some(state) = self.by_signature.get_mut(signature) {
+            Self::observe_processed_once(state, now);
+        }
+    }
+
+    fn mark_processed_with_slot(&mut self, signature: &Signature, slot: Slot, now: Instant) {
+        if let Some(state) = self.by_signature.get_mut(signature) {
+            Self::observe_processed_once(state, now);
+            if state.slot.is_none() {
+                state.slot = Some(slot);
+                self.by_slot
+                    .entry(slot)
+                    .or_default()
+                    .push(signature.to_owned());
+                let t3 = Self::effective_t3(signature, state);
+                custom_metrics::observe_tx_execution_in_block_latency_us(
+                    now.saturating_duration_since(t3).as_micros() as u64,
+                );
+            }
+        }
+    }
+
+    fn mark_confirmed(&mut self, signature: &Signature, now: Instant) {
+        if let Some(state) = self.by_signature.get_mut(signature) {
+            if !state.confirmed {
+                custom_metrics::observe_time_to_confirmed_us(
+                    now.saturating_duration_since(state.t1).as_micros() as u64,
+                );
+                state.confirmed = true;
+            }
+        }
+    }
+
+    fn mark_confirmed_up_to_slot(&mut self, slot: Slot, now: Instant) {
+        for state in self.by_signature.values_mut() {
+            if state.slot.is_some_and(|signature_slot| signature_slot <= slot) && !state.confirmed {
+                custom_metrics::observe_time_to_confirmed_us(
+                    now.saturating_duration_since(state.t1).as_micros() as u64,
+                );
+                state.confirmed = true;
+            }
+        }
+    }
+
+    fn mark_finalized(&mut self, signature: &Signature, now: Instant) {
+        if let Some(state) = self.by_signature.remove(signature) {
+            if let Some(slot) = state.slot {
+                self.remove_signature_from_slot(slot, signature);
+            }
+            custom_metrics::clear_tx_acceptance_time(signature);
+            if !state.finalized {
+                custom_metrics::observe_time_to_finalized_us(
+                    now.saturating_duration_since(state.t1).as_micros() as u64,
+                );
+            }
+        }
+    }
+
+    fn mark_finalized_up_to_slot(&mut self, slot: Slot, now: Instant) {
+        let mut finalized_signatures = Vec::new();
+        for (signature, state) in &self.by_signature {
+            if state.slot.is_some_and(|signature_slot| signature_slot <= slot) {
+                finalized_signatures.push(signature.to_owned());
+            }
+        }
+
+        for signature in finalized_signatures {
+            self.mark_finalized(&signature, now);
+        }
+    }
+
+    fn mark_block_produced(&mut self, slot: Slot, now: Instant) {
+        let Some(signatures) = self.by_slot.remove(&slot) else {
+            return;
+        };
+        for signature in signatures {
+            if let Some(state) = self.by_signature.get_mut(&signature) {
+                let t3 = Self::effective_t3(&signature, state);
+                custom_metrics::observe_block_production_latency_us(
+                    now.saturating_duration_since(t3).as_micros() as u64,
+                );
+            }
+        }
+    }
+
+    fn maybe_sweep_timeouts(&mut self, now: Instant) {
+        if self
+            .last_sweep
+            .is_some_and(|last| now.saturating_duration_since(last) < SWEEP_INTERVAL)
+        {
+            return;
+        }
+        self.last_sweep = Some(now);
+
+        let mut timed_out = 0_u64;
+        let mut expired_signatures = Vec::new();
+        for (signature, state) in &self.by_signature {
+            if !state.confirmed
+                && now.saturating_duration_since(state.t1) >= CONFIRMATION_TIMEOUT
+            {
+                timed_out += 1;
+                expired_signatures.push((signature.to_owned(), state.slot));
+            }
+        }
+        for (signature, maybe_slot) in expired_signatures {
+            self.by_signature.remove(&signature);
+            if let Some(slot) = maybe_slot {
+                self.remove_signature_from_slot(slot, &signature);
+            }
+            custom_metrics::clear_tx_acceptance_time(&signature);
+        }
+        if timed_out > 0 {
+            custom_metrics::inc_confirmation_timeout_rate(timed_out);
+        }
+    }
+}
+
+static TRACKER: LazyLock<Mutex<SignatureMetricsTracker>> =
+    LazyLock::new(|| Mutex::new(SignatureMetricsTracker::default()));
+
+pub fn register_signature(signature: Signature, t1: Instant, t3_proxy: Instant) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.register(signature, t1, t3_proxy);
+    }
+}
+
+pub fn mark_processed(signature: &Signature) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_processed(signature, Instant::now());
+    }
+}
+
+pub fn mark_processed_with_slot(signature: &Signature, slot: Slot) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_processed_with_slot(signature, slot, Instant::now());
+    }
+}
+
+pub fn mark_confirmed(signature: &Signature) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_confirmed(signature, Instant::now());
+    }
+}
+
+pub fn mark_confirmed_up_to_slot(slot: Slot) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_confirmed_up_to_slot(slot, Instant::now());
+    }
+}
+
+pub fn mark_finalized(signature: &Signature) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_finalized(signature, Instant::now());
+    }
+}
+
+pub fn mark_finalized_up_to_slot(slot: Slot) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_finalized_up_to_slot(slot, Instant::now());
+    }
+}
+
+pub fn mark_block_produced(slot: Slot) {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.mark_block_produced(slot, Instant::now());
+    }
+}
+
+pub fn is_tracked(signature: &Signature) -> bool {
+    if let Ok(mut tracker) = TRACKER.lock() {
+        tracker.maybe_sweep_timeouts(Instant::now());
+        tracker.by_signature.contains_key(signature)
+    } else {
+        false
+    }
+}
+
+pub fn start_timeout_sweeper(exit: Arc<AtomicBool>) -> JoinHandle<()> {
+    Builder::new()
+        .name("solSigMetricsSweep".to_string())
+        .spawn(move || {
+            while !exit.load(Ordering::Relaxed) {
+                if let Ok(mut tracker) = TRACKER.lock() {
+                    tracker.maybe_sweep_timeouts(Instant::now());
+                }
+                thread::sleep(SWEEP_INTERVAL);
+            }
+        })
+        .expect("signature timeout sweeper thread must start")
+}

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -4,7 +4,10 @@
 //! frozen banks it receives.
 
 use {
-    crate::transaction_notifier_interface::TransactionNotifierArc,
+    crate::{
+        signature_metrics_tracker, transaction_notifier_interface::TransactionNotifierArc,
+        tx_type_rules,
+    },
     crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::izip,
     solana_clock::Slot,
@@ -12,6 +15,7 @@ use {
         blockstore::{Blockstore, BlockstoreError},
         blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
     },
+    solana_metrics::custom_metrics,
     solana_runtime::{
         bank::{Bank, KeyedRewardsAndNumPartitions},
         dependency_tracker::DependencyTracker,
@@ -175,6 +179,21 @@ impl TransactionStatusService {
                         fee_details,
                         ..
                     } = committed_tx;
+                    let is_tracked = signature_metrics_tracker::is_tracked(transaction.signature());
+                    if is_tracked {
+                        let tx_type = tx_type_rules::infer_from_transaction(&transaction);
+                        if status.is_ok() {
+                            custom_metrics::inc_tx_executed_total(1);
+                            custom_metrics::inc_tx_executed_total_with_type(1, &tx_type);
+                        } else {
+                            custom_metrics::inc_tx_failed_total(1);
+                            custom_metrics::inc_tx_failed_total_with_type(1, &tx_type);
+                        }
+                    }
+                    signature_metrics_tracker::mark_processed_with_slot(
+                        transaction.signature(),
+                        slot,
+                    );
 
                     let fee = fee_details.total_fee();
                     let inner_instructions = inner_instructions.map(|inner_instructions| {
@@ -265,6 +284,7 @@ impl TransactionStatusService {
                 if !bank.is_frozen() {
                     return Err(Error::NonFrozenBank(bank.slot()));
                 }
+                signature_metrics_tracker::mark_block_produced(bank.slot());
                 Self::write_block_meta(&bank, blockstore)?;
                 max_complete_transaction_status_slot.fetch_max(bank.slot(), Ordering::SeqCst);
             }

--- a/rpc/src/tx_type_rules.rs
+++ b/rpc/src/tx_type_rules.rs
@@ -1,0 +1,119 @@
+use {
+    solana_message::SanitizedMessage,
+    solana_pubkey::Pubkey,
+    solana_sha256_hasher::hash,
+    solana_transaction::sanitized::SanitizedTransaction,
+    std::{
+        collections::HashMap,
+        sync::{LazyLock, RwLock},
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcTxTypeRule {
+    pub program_id: Pubkey,
+    pub discriminator: [u8; 8],
+    pub tx_type: String,
+}
+
+type TxTypeRuleMap = HashMap<(Pubkey, [u8; 8]), String>;
+
+static TX_TYPE_RULES: LazyLock<RwLock<TxTypeRuleMap>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+pub fn set_rules(rules: Vec<RpcTxTypeRule>) {
+    let map = rules
+        .into_iter()
+        .map(|rule| ((rule.program_id, rule.discriminator), rule.tx_type))
+        .collect::<TxTypeRuleMap>();
+    if let Ok(mut guard) = TX_TYPE_RULES.write() {
+        *guard = map;
+    }
+}
+
+pub fn infer_from_message(message: &SanitizedMessage, is_simple_vote: bool) -> String {
+    if is_simple_vote {
+        return "vote".to_string();
+    }
+
+    if let Ok(guard) = TX_TYPE_RULES.read() {
+        for (program_id, instruction) in message.program_instructions_iter() {
+            let Some(data) = instruction.data.get(0..8) else {
+                continue;
+            };
+            let mut discriminator = [0_u8; 8];
+            discriminator.copy_from_slice(data);
+            if let Some(tx_type) = guard.get(&(*program_id, discriminator)) {
+                return tx_type.clone();
+            }
+        }
+    }
+
+    if let Some((program_id, _)) = message.program_instructions_iter().next() {
+        if *program_id == solana_system_interface::program::id() {
+            "system".to_string()
+        } else if *program_id == spl_generic_token::token::id() {
+            "spl_token".to_string()
+        } else if *program_id == spl_generic_token::token_2022::id() {
+            "spl_token_2022".to_string()
+        } else if *program_id == solana_stake_program::id() {
+            "stake".to_string()
+        } else if *program_id == solana_vote_program::id() {
+            "vote_program".to_string()
+        } else {
+            "unknown".to_string()
+        }
+    } else {
+        "unknown".to_string()
+    }
+}
+
+pub fn infer_from_transaction(transaction: &SanitizedTransaction) -> String {
+    infer_from_message(
+        transaction.message(),
+        transaction.is_simple_vote_transaction(),
+    )
+}
+
+pub fn parse_discriminator(input: &str) -> Result<[u8; 8], String> {
+    let value = input.trim();
+    if value.is_empty() {
+        return Err("empty discriminator".to_string());
+    }
+
+    let hex_value = value.strip_prefix("0x").unwrap_or(value);
+    let is_hex = value.starts_with("0x")
+        || hex_value
+            .chars()
+            .any(|c| matches!(c, 'a'..='f' | 'A'..='F'));
+    if is_hex {
+        if hex_value.len() != 16 {
+            return Err(format!(
+                "invalid discriminator hex length: expected 16, got {}",
+                hex_value.len()
+            ));
+        }
+
+        let mut out = [0_u8; 8];
+        for i in 0..8 {
+            let start = i * 2;
+            let byte = u8::from_str_radix(&hex_value[start..start + 2], 16)
+                .map_err(|err| format!("invalid discriminator hex: {err}"))?;
+            out[i] = byte;
+        }
+        return Ok(out);
+    }
+
+    let method_number = value
+        .parse::<u64>()
+        .map_err(|err| format!("invalid discriminator number `{value}`: {err}"))?;
+    Ok(method_number.to_le_bytes())
+}
+
+pub fn anchor_discriminator_from_method_name(method_name: &str) -> [u8; 8] {
+    let preimage = format!("global:{method_name}");
+    let digest = hash(preimage.as_bytes()).to_bytes();
+    let mut out = [0_u8; 8];
+    out.copy_from_slice(&digest[..8]);
+    out
+}

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -68,6 +68,9 @@ pub struct TransactionInfo {
     pub last_valid_block_height: u64,
     pub durable_nonce_info: Option<(Pubkey, Hash)>,
     pub max_retries: Option<usize>,
+    pub received_at: Instant,
+    pub forwarded_at: Instant,
+    pub tx_type: String,
     retries: usize,
     /// Last time the transaction was sent
     last_sent_time: Option<Instant>,
@@ -84,6 +87,32 @@ impl TransactionInfo {
         max_retries: Option<usize>,
         last_sent_time: Option<Instant>,
     ) -> Self {
+        Self::new_with_timing(
+            message_hash,
+            signature,
+            blockhash,
+            wire_transaction,
+            last_valid_block_height,
+            durable_nonce_info,
+            max_retries,
+            Instant::now(),
+            Instant::now(),
+            last_sent_time,
+        )
+    }
+
+    pub fn new_with_timing(
+        message_hash: Hash,
+        signature: Signature,
+        blockhash: Hash,
+        wire_transaction: Vec<u8>,
+        last_valid_block_height: u64,
+        durable_nonce_info: Option<(Pubkey, Hash)>,
+        max_retries: Option<usize>,
+        received_at: Instant,
+        forwarded_at: Instant,
+        last_sent_time: Option<Instant>,
+    ) -> Self {
         Self {
             message_hash,
             signature,
@@ -92,9 +121,17 @@ impl TransactionInfo {
             last_valid_block_height,
             durable_nonce_info,
             max_retries,
+            received_at,
+            forwarded_at,
+            tx_type: "unknown".to_string(),
             retries: 0,
             last_sent_time,
         }
+    }
+
+    pub fn with_tx_type(mut self, tx_type: String) -> Self {
+        self.tx_type = tx_type;
+        self
     }
 
     fn get_max_retries(
@@ -276,10 +313,45 @@ impl SendTransactionService {
                             let retry_len = retry_transactions.len();
                             let entry = retry_transactions.entry(signature);
                             if let Entry::Vacant(_) = entry {
-                                if retry_len >= retry_pool_max_size {
-                                    break;
-                                } else {
-                                    transaction_info.last_sent_time = Some(last_sent_time);
+                                    if retry_len >= retry_pool_max_size {
+                                        solana_metrics::custom_metrics::inc_tx_dropped_total(1);
+                                        solana_metrics::custom_metrics::inc_tx_dropped_total_with_type(
+                                            1,
+                                            &transaction_info.tx_type,
+                                        );
+                                        break;
+                                    } else {
+                                        transaction_info.last_sent_time = Some(last_sent_time);
+                                    let accepted_at = Instant::now();
+                                    let mempool_acceptance_latency_us = accepted_at
+                                        .saturating_duration_since(transaction_info.forwarded_at)
+                                        .as_micros() as u64;
+                                    let acknowledge_latency_us = accepted_at
+                                        .saturating_duration_since(transaction_info.received_at)
+                                        .as_micros() as u64;
+                                    solana_metrics::custom_metrics::observe_mempool_acceptance_latency_us(
+                                        mempool_acceptance_latency_us,
+                                    );
+                                    solana_metrics::custom_metrics::observe_mempool_acceptance_latency_us_with_type(
+                                        mempool_acceptance_latency_us,
+                                        &transaction_info.tx_type,
+                                    );
+                                    solana_metrics::custom_metrics::observe_acknowledge_latency_us(
+                                        acknowledge_latency_us,
+                                    );
+                                    solana_metrics::custom_metrics::observe_acknowledge_latency_us_with_type(
+                                        acknowledge_latency_us,
+                                        &transaction_info.tx_type,
+                                    );
+                                    solana_metrics::custom_metrics::inc_tx_accepted_total(1);
+                                    solana_metrics::custom_metrics::inc_tx_accepted_total_with_type(
+                                        1,
+                                        &transaction_info.tx_type,
+                                    );
+                                    solana_metrics::custom_metrics::register_tx_acceptance_time(
+                                        transaction_info.signature,
+                                        accepted_at,
+                                    );
                                     transactions_added_to_retry += 1;
                                     entry.or_insert(transaction_info);
                                 }
@@ -290,6 +362,15 @@ impl SendTransactionService {
                         stats
                             .retry_queue_overflow
                             .fetch_add(retry_queue_overflow as u64, Ordering::Relaxed);
+                        if retry_queue_overflow > 0 {
+                            solana_metrics::custom_metrics::inc_tx_dropped_total(
+                                retry_queue_overflow as u64,
+                            );
+                            solana_metrics::custom_metrics::inc_tx_dropped_total_with_type(
+                                retry_queue_overflow as u64,
+                                "other",
+                            );
+                        }
                         stats
                             .retry_queue_size
                             .store(retry_transactions.len() as u64, Ordering::Relaxed);
@@ -414,6 +495,12 @@ impl SendTransactionService {
                     info!("Dropping expired durable-nonce transaction: {signature}");
                     result.expired += 1;
                     stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
+                    solana_metrics::custom_metrics::inc_tx_expired_total(1);
+                    solana_metrics::custom_metrics::inc_tx_expired_total_with_type(
+                        1,
+                        &transaction_info.tx_type,
+                    );
+                    solana_metrics::custom_metrics::clear_tx_acceptance_time(signature);
                     return false;
                 }
             }
@@ -421,6 +508,12 @@ impl SendTransactionService {
                 info!("Dropping expired transaction: {signature}");
                 result.expired += 1;
                 stats.expired_transactions.fetch_add(1, Ordering::Relaxed);
+                solana_metrics::custom_metrics::inc_tx_expired_total(1);
+                solana_metrics::custom_metrics::inc_tx_expired_total_with_type(
+                    1,
+                    &transaction_info.tx_type,
+                );
+                solana_metrics::custom_metrics::clear_tx_acceptance_time(signature);
                 return false;
             }
 
@@ -434,6 +527,7 @@ impl SendTransactionService {
                     stats
                         .transactions_exceeding_max_retries
                         .fetch_add(1, Ordering::Relaxed);
+                    solana_metrics::custom_metrics::clear_tx_acceptance_time(signature);
                     return false;
                 }
             }
@@ -481,6 +575,7 @@ impl SendTransactionService {
                         info!("Dropping failed transaction: {signature}");
                         result.failed += 1;
                         stats.failed_transactions.fetch_add(1, Ordering::Relaxed);
+                        solana_metrics::custom_metrics::clear_tx_acceptance_time(signature);
                         false
                     } else {
                         result.retained += 1;
@@ -591,6 +686,9 @@ mod test {
             last_valid_block_height: 0,
             durable_nonce_info: None,
             max_retries: None,
+            received_at: Instant::now(),
+            forwarded_at: Instant::now(),
+            tx_type: "unknown".to_string(),
             retries: 0,
             last_sent_time: None,
         };

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -2,6 +2,7 @@ use {
     agave_validator::{
         admin_rpc_service, cli, dashboard::Dashboard, ledger_lockfile, lock_ledger,
         println_name_value,
+        commands::run::args::json_rpc_config::load_tx_type_rules,
     },
     clap::{crate_name, value_t, value_t_or_exit, values_t_or_exit},
     crossbeam_channel::unbounded,
@@ -460,6 +461,10 @@ fn main() {
     } else {
         None
     };
+    let tx_type_rules = load_tx_type_rules(&matches).unwrap_or_else(|err| {
+        println!("Error: failed to parse tx type mapping rules: {err}");
+        exit(1);
+    });
 
     genesis
         .ledger_path(&ledger_path)
@@ -493,6 +498,7 @@ fn main() {
         rpc_bigtable_config,
         faucet_addr: Some(faucet_addr),
         account_indexes,
+        tx_type_rules,
         ..JsonRpcConfig::default_for_test()
     });
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -598,6 +598,25 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Enable the unstable RPC PubSub `blockSubscribe` subscription"),
         )
         .arg(
+            Arg::with_name("rpc_tx_type_map_config")
+                .long("rpc-tx-type-map-config")
+                .value_name("FILE")
+                .takes_value(true)
+                .help(
+                    "Path to YAML/JSON config that maps tx type by program and 8-byte instruction discriminator",
+                ),
+        )
+        .arg(
+            Arg::with_name("rpc_tx_type_map_rule")
+                .long("rpc-tx-type-map-rule")
+                .value_name("PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE")
+                .takes_value(true)
+                .multiple(true)
+                .help(
+                    "Inline tx type mapping rule. Use METHOD_NAME for Anchor (sha256(\"global:METHOD_NAME\")[0..8]), explicit DISCRIMINATOR_HEX, or DISCRIMINATOR_U64 (converted via little-endian to 8 bytes) for matching instruction_data[0..8]",
+                ),
+        )
+        .arg(
             Arg::with_name("bpf_program")
                 .long("bpf-program")
                 .value_names(&["ADDRESS_OR_KEYPAIR", "SBF_PROGRAM.SO"])

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1270,6 +1270,25 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("The maximum request body size accepted by rpc service"),
     )
     .arg(
+        Arg::with_name("rpc_tx_type_map_config")
+            .long("rpc-tx-type-map-config")
+            .value_name("FILE")
+            .takes_value(true)
+            .help(
+                "Path to YAML/JSON config that maps tx type by program and 8-byte instruction discriminator",
+            ),
+    )
+    .arg(
+        Arg::with_name("rpc_tx_type_map_rule")
+            .long("rpc-tx-type-map-rule")
+            .value_name("PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE")
+            .takes_value(true)
+            .multiple(true)
+            .help(
+                "Inline tx type mapping rule. Use METHOD_NAME for Anchor (sha256(\"global:METHOD_NAME\")[0..8]), explicit DISCRIMINATOR_HEX, or DISCRIMINATOR_U64 (converted via little-endian to 8 bytes) for matching instruction_data[0..8]",
+            ),
+    )
+    .arg(
         Arg::with_name("geyser_plugin_config")
             .long("geyser-plugin-config")
             .alias("accountsdb-plugin-config")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -1,8 +1,13 @@
 use {
     crate::commands::{FromClapArgMatches, Result},
     clap::{value_t, ArgMatches},
+    serde::Deserialize,
     solana_accounts_db::accounts_index::AccountSecondaryIndexes,
-    solana_rpc::rpc::{JsonRpcConfig, RpcBigtableConfig},
+    solana_rpc::{
+        rpc::{JsonRpcConfig, RpcBigtableConfig},
+        tx_type_rules::{anchor_discriminator_from_method_name, parse_discriminator, RpcTxTypeRule},
+    },
+    std::{fs, str::FromStr},
 };
 
 impl FromClapArgMatches for JsonRpcConfig {
@@ -14,6 +19,7 @@ impl FromClapArgMatches for JsonRpcConfig {
         } else {
             None
         };
+        let tx_type_rules = load_tx_type_rules(matches)?;
 
         Ok(JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
@@ -40,9 +46,152 @@ impl FromClapArgMatches for JsonRpcConfig {
             full_api: matches.is_present("full_rpc_api"),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             max_request_body_size: Some(value_t!(matches, "rpc_max_request_body_size", usize)?),
+            tx_type_rules,
             disable_health_check: false,
         })
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DiscriminatorInput {
+    String(String),
+    Number(u64),
+}
+
+impl DiscriminatorInput {
+    fn as_text(&self) -> String {
+        match self {
+            Self::String(value) => value.clone(),
+            Self::Number(value) => value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcTxTypeRuleSerde {
+    program_id: String,
+    discriminator: Option<DiscriminatorInput>,
+    method_name: Option<String>,
+    tx_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcTxTypeRuleFile {
+    rules: Vec<RpcTxTypeRuleSerde>,
+}
+
+fn parse_tx_type_rule(
+    program_id: &str,
+    discriminator_input: Option<&str>,
+    method_name: Option<&str>,
+    tx_type: &str,
+) -> Result<RpcTxTypeRule> {
+    let program_id = solana_pubkey::Pubkey::from_str(program_id).map_err(|err| {
+        crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+            "invalid program_id `{program_id}` in tx type rule: {err}"
+        )))
+    })?;
+    let discriminator = if let Some(method_name) = method_name {
+        anchor_discriminator_from_method_name(method_name)
+    } else if let Some(discriminator_input) = discriminator_input {
+        parse_discriminator(discriminator_input).map_err(|err| {
+            crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+                "invalid discriminator `{discriminator_input}` in tx type rule: {err}"
+            )))
+        })?
+    } else {
+        return Err(crate::commands::Error::Dynamic(
+            Box::<dyn std::error::Error>::from(
+                "tx type rule must provide either `method_name` or `discriminator`".to_string(),
+            ),
+        ));
+    };
+    Ok(RpcTxTypeRule {
+        program_id,
+        discriminator,
+        tx_type: tx_type.to_string(),
+    })
+}
+
+fn parse_inline_rule(rule: &str) -> Result<RpcTxTypeRule> {
+    let mut parts = rule.splitn(3, ':');
+    let Some(program_id) = parts.next() else {
+        unreachable!();
+    };
+    let Some(method_or_discriminator) = parts.next() else {
+        return Err(crate::commands::Error::Dynamic(
+            Box::<dyn std::error::Error>::from(format!(
+                "invalid `--rpc-tx-type-map-rule` format `{rule}`; expected PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE"
+            )),
+        ));
+    };
+    let Some(tx_type) = parts.next() else {
+        return Err(crate::commands::Error::Dynamic(
+            Box::<dyn std::error::Error>::from(format!(
+                "invalid `--rpc-tx-type-map-rule` format `{rule}`; expected PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE"
+            )),
+        ));
+    };
+    let method_name = if parse_discriminator(method_or_discriminator).is_err() {
+        Some(method_or_discriminator)
+    } else {
+        None
+    };
+    let discriminator_input = if method_name.is_none() {
+        Some(method_or_discriminator)
+    } else {
+        None
+    };
+    parse_tx_type_rule(program_id, discriminator_input, method_name, tx_type)
+}
+
+pub fn load_tx_type_rules(matches: &ArgMatches) -> Result<Vec<RpcTxTypeRule>> {
+    let mut rules = Vec::new();
+
+    if let Some(path) = matches.value_of("rpc_tx_type_map_config") {
+        let content = fs::read_to_string(path).map_err(|err| {
+            crate::commands::Error::Dynamic(Box::<dyn std::error::Error>::from(format!(
+                "failed to read --rpc-tx-type-map-config `{path}`: {err}"
+            )))
+        })?;
+
+        if let Ok(file) = serde_yaml::from_str::<RpcTxTypeRuleFile>(&content) {
+            for rule in file.rules {
+                let discriminator_text = rule.discriminator.as_ref().map(DiscriminatorInput::as_text);
+                rules.push(parse_tx_type_rule(
+                    &rule.program_id,
+                    discriminator_text.as_deref(),
+                    rule.method_name.as_deref(),
+                    &rule.tx_type,
+                )?);
+            }
+        } else if let Ok(file_rules) = serde_yaml::from_str::<Vec<RpcTxTypeRuleSerde>>(&content) {
+            for rule in file_rules {
+                let discriminator_text = rule.discriminator.as_ref().map(DiscriminatorInput::as_text);
+                rules.push(parse_tx_type_rule(
+                    &rule.program_id,
+                    discriminator_text.as_deref(),
+                    rule.method_name.as_deref(),
+                    &rule.tx_type,
+                )?);
+            }
+        } else {
+            return Err(crate::commands::Error::Dynamic(
+                Box::<dyn std::error::Error>::from(format!(
+                    "failed to parse --rpc-tx-type-map-config `{path}`; expected YAML/JSON list of rules or {{rules: [...]}}"
+                )),
+            ));
+        }
+    }
+
+    if let Some(values) = matches.values_of("rpc_tx_type_map_rule") {
+        for value in values {
+            rules.push(parse_inline_rule(value)?);
+        }
+    }
+
+    Ok(rules)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Parasol Custom Metrics

This project exposes custom node metrics via:

- `GET /metrics`

Typical URL:

- `http://<RPC_HOST>:<RPC_PORT>/metrics`
- Example: `http://127.0.0.1:8899/metrics`

## Main Metrics

### Counters

- `tx_accepted_total`: transactions accepted into the node retry/acceptance pipeline (deterministic acceptance point).
- `tx_executed_total`: committed transactions with successful execution (`status=Ok`).
- `tx_failed_total`: committed failed transactions (`status=Err`) and failed outcomes in retry flow.
- `tx_dropped_total`: transactions dropped before execution (ingress/scheduler/retry-pool overflow paths).
- `tx_expired_total`: transactions dropped due to expiry (blockhash/nonce validity window).
- `confirmation_timeout_rate`: tracked signatures that did not reach confirmation within timeout.
- `account_lock_conflict_rate`: lock conflict occurrences (`AccountInUse`-like execution contention).
- `retry_due_to_account_in_use_rate`: retries caused by account lock contention.
- `fork_rate`: fork-failure signal from replay/heaviest-fork failure states.
- `duplicate_confirmed_blocks`: duplicate-confirmed slot/hash events observed by replay logic.

### Gauge

- `avg_locked_accounts_per_tx`: average locked-account footprint per transaction.

### Histograms

- `node_ingress_latency_seconds`: RPC ingress processing latency (`t1 -> t2` proxy).
- `mempool_acceptance_latency_seconds`: acceptance latency in send-transaction-service (`t2 -> t3`).
- `acknowledge_latency_seconds`: end-to-end node acknowledge latency (`t1 -> t3`).
- `decision_response_latency_seconds`: node decision response latency in current RPC path (`forwarded -> RPC return` proxy).
- `node_to_decision_response_latency_seconds`: request-to-response latency at node side (`t1 -> response point`).
- `time_to_processed_seconds`: signature lifecycle latency to processed commitment.
- `time_to_confirmed_seconds`: signature lifecycle latency to confirmed commitment.
- `time_to_finalized_seconds`: signature lifecycle latency to finalized commitment.
- `tx_execution_in_block_latency_seconds`: latency from acceptance to processed execution in block (`t3 -> t5`, exact `t3` when available).
- `block_production_latency_seconds`: latency from acceptance to produced/frozen block (`t3 -> t6`, exact `t3` when available).
- `state_update_notification_latency_seconds`: pubsub notification preparation/queue/send latency (`t6 -> t7` approximation).
- `blockhash_fetch_latency_seconds`: RPC latency for `getLatestBlockhash`.
- `blockhash_age_at_submit_slots`: age of submitted blockhash at send time (in slots).
- `blockhash_remaining_validity_slots`: remaining validity window of submitted blockhash (in slots).

## `tx_type` Label Mapping (Config / CLI)

`tx_type` can be derived by rules keyed by:

- `program_id`
- first 8 bytes of `instruction_data` (instruction discriminator)

For Anchor methods, discriminator is computed as:

- `sha256("global:<method_name>")[0..8]`

### CLI Examples

Use a config file:

```bash
agave-validator \
  --rpc-tx-type-map-config /path/to/tx_type_rules.yaml
```

Inline rules (repeatable):

```bash
agave-validator \
  --rpc-tx-type-map-rule <PROGRAM_ID>:place_order:place_order \
  --rpc-tx-type-map-rule <PROGRAM_ID>:42:cancel_order \
  --rpc-tx-type-map-rule <PROGRAM_ID>:0x0102030405060708:liquidation
```

Rule format:

- `PROGRAM_ID:METHOD_NAME|DISCRIMINATOR_HEX|DISCRIMINATOR_U64:TX_TYPE`

`DISCRIMINATOR_U64` is converted with `to_le_bytes()` and matched against `instruction_data[0..8]`.

### Config File Example (YAML)

```yaml
rules:
  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
    method_name: place_order
    tx_type: place_order

  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
    discriminator: 42
    tx_type: cancel_order

  - program_id: 9xQeWvG816bUx9EPf2zj8F8oQv5gZ6kR3X4Y5Z6a7b8c
    discriminator: 0x0102030405060708
    tx_type: liquidation
```
