### PR TITLE
PRS-104, updated clean accounts logic

### DIFF
--- a/accounts-db/src/account_utils.rs
+++ b/accounts-db/src/account_utils.rs
@@ -1,7 +1,6 @@
 use {
-    solana_account::ReadableAccount,
-    solana_clock::Epoch,
-    solana_pubkey::Pubkey,
+    solana_account::ReadableAccount, solana_clock::Epoch, solana_pubkey::Pubkey,
+    solana_system_interface::program as system_program,
 };
 
 pub(crate) fn is_default_account_meta(
@@ -20,6 +19,31 @@ pub(crate) fn is_default_account_meta(
 
 pub(crate) fn is_default_account(account: &impl ReadableAccount) -> bool {
     is_default_account_meta(
+        account.lamports(),
+        account.data().len(),
+        account.owner(),
+        account.executable(),
+        account.rent_epoch(),
+    )
+}
+
+/// Accounts that can be purged by zero-lamport clean.
+///
+/// In this fork, in addition to classic default tombstones, we also treat
+/// `owner = system_program`, `lamports = 0`, `data_len = 0` as cleanable.
+pub(crate) fn is_cleanable_zero_lamport_account_meta(
+    lamports: u64,
+    data_len: usize,
+    owner: &Pubkey,
+    executable: bool,
+    rent_epoch: Epoch,
+) -> bool {
+    is_default_account_meta(lamports, data_len, owner, executable, rent_epoch)
+        || (lamports == 0 && data_len == 0 && owner == &system_program::id())
+}
+
+pub(crate) fn is_cleanable_zero_lamport_account(account: &impl ReadableAccount) -> bool {
+    is_cleanable_zero_lamport_account_meta(
         account.lamports(),
         account.data().len(),
         account.owner(),

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -201,15 +201,6 @@ impl Accounts {
         self.load_slow(ancestors, pubkey, LoadHint::Unspecified)
     }
 
-    pub fn load_without_fixed_root_allow_tombstone(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.accounts_db
-            .load_allow_tombstone(ancestors, pubkey, LoadHint::Unspecified)
-    }
-
     /// scans underlying accounts_db for this delta (slot) with a map function
     ///   from LoadedAccount to B
     /// returns only the latest/current version of B for this slot
@@ -253,10 +244,11 @@ impl Accounts {
         program_id: Option<&Pubkey>,
     ) -> Vec<TransactionAccount> {
         self.scan_slot(slot, |stored_account| {
-            program_id
+            (stored_account.is_loadable()
+                && program_id
                 .map(|program_id| program_id == stored_account.owner())
-                .unwrap_or(true)
-                .then(|| (*stored_account.pubkey(), stored_account.take_account()))
+                .unwrap_or(true))
+            .then(|| (*stored_account.pubkey(), stored_account.take_account()))
         })
     }
 
@@ -798,6 +790,46 @@ mod tests {
         assert_eq!(loaded, vec![(pubkey2, account2)]);
         let loaded = accounts.load_by_program_slot(0, Some(&Pubkey::from([4; 32])));
         assert_eq!(loaded, vec![]);
+    }
+
+    #[test]
+    fn test_load_by_program_slot_filters_cleanable_system_zero_lamport_account() {
+        let accounts_db = AccountsDb::new_single_for_tests();
+        let accounts = Accounts::new(Arc::new(accounts_db));
+
+        let program_id = solana_sdk_ids::system_program::id();
+
+        let live_pubkey = solana_pubkey::new_rand();
+        let live_account = AccountSharedData::new(1, 0, &program_id);
+        accounts.store_for_tests(0, &live_pubkey, &live_account);
+
+        let dead_pubkey = solana_pubkey::new_rand();
+        let mut dead_account = AccountSharedData::default();
+        dead_account.set_owner(program_id);
+        dead_account.set_rent_epoch(u64::MAX - 1);
+        accounts.store_for_tests(0, &dead_pubkey, &dead_account);
+
+        accounts.add_root_and_flush_write_cache(0);
+
+        let loaded = accounts.load_by_program_slot(0, Some(&program_id));
+        assert_eq!(loaded, vec![(live_pubkey, live_account)]);
+    }
+
+    #[test]
+    fn test_load_by_program_slot_keeps_noncleanable_zero_lamport_system_account() {
+        let accounts_db = AccountsDb::new_single_for_tests();
+        let accounts = Accounts::new(Arc::new(accounts_db));
+
+        let program_id = solana_sdk_ids::system_program::id();
+
+        let pubkey = solana_pubkey::new_rand();
+        let account = AccountSharedData::new(0, 1, &program_id);
+        accounts.store_for_tests(0, &pubkey, &account);
+
+        accounts.add_root_and_flush_write_cache(0);
+
+        let loaded = accounts.load_by_program_slot(0, Some(&program_id));
+        assert_eq!(loaded, vec![(pubkey, account)]);
     }
 
     #[test_case(false; "old")]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -28,11 +28,13 @@ use crate::append_vec::StoredAccountMeta;
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        account_utils::{is_default_account, is_default_account_meta},
         account_info::{AccountInfo, Offset, StorageLocation},
         account_storage::{
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
             AccountStorage, AccountStorageStatus, AccountStoragesOrderer, ShrinkInProgress,
+        },
+        account_utils::{
+            is_cleanable_zero_lamport_account, is_cleanable_zero_lamport_account_meta,
         },
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_db::stats::{
@@ -95,6 +97,8 @@ use {
     },
     tempfile::TempDir,
 };
+#[cfg(test)]
+use crate::account_utils::is_default_account;
 
 // when the accounts write cache exceeds this many bytes, we will flush it
 // this can be specified on the command line, too (--accounts-db-cache-limit-mb)
@@ -253,16 +257,15 @@ pub enum StoreReclaims {
     Ignore,
 }
 
-/// specifies how to return tombstone accounts from a load
+/// specifies how to return zero-lamport tombstone-like accounts from a load
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LoadZeroLamports {
-    /// return None if loaded account is a default tombstone
+    /// return None if loaded account is cleanable by zero-lamport clean
     None,
-    /// return Some(account) even if it is a default tombstone
-    /// This used to be the only behavior.
-    /// Note that this is non-deterministic if clean is running asynchronously.
-    /// If a zero lamport account exists in the index, then Some is returned.
-    /// Once it is cleaned from the index, None is returned.
+    /// return Some(account) even if it is a zero-lamport tombstone-like account.
+    /// This is retained for tests and internal paths that need visibility into
+    /// index state before asynchronous clean catches up.
+    #[cfg_attr(not(test), allow(dead_code))]
     Some,
 }
 
@@ -2010,7 +2013,7 @@ impl AccountsDb {
                             .accounts
                             .scan_accounts_without_data(|_offset, account| {
                                 let pubkey = *account.pubkey();
-                                let is_tombstone = is_default_account_meta(
+                                let is_tombstone = is_cleanable_zero_lamport_account_meta(
                                     account.lamports,
                                     account.data_len,
                                     account.owner,
@@ -2970,7 +2973,7 @@ impl AccountsDb {
             .scan_accounts_without_data(|offset, account| {
                 // file_id is unused and can be anything. We will always be loading whatever storage is in the slot.
                 let file_id = 0;
-                let is_tombstone = is_default_account_meta(
+                let is_tombstone = is_cleanable_zero_lamport_account_meta(
                     account.lamports,
                     account.data_len,
                     account.owner,
@@ -4095,15 +4098,6 @@ impl AccountsDb {
         self.do_load(ancestors, pubkey, None, load_hint, LoadZeroLamports::None)
     }
 
-    pub fn load_allow_tombstone(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        load_hint: LoadHint,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(ancestors, pubkey, None, load_hint, LoadZeroLamports::Some)
-    }
-
     /// load the account with `pubkey` into the read only accounts cache.
     /// The goal is to make subsequent loads (which caller expects to occur) to find the account quickly.
     pub fn load_account_into_read_cache(&self, ancestors: &Ancestors, pubkey: &Pubkey) {
@@ -4118,7 +4112,7 @@ impl AccountsDb {
         );
     }
 
-    /// note this returns None for default tombstone accounts
+    /// note this returns None for cleanable tombstone-like accounts
     pub fn load_with_fixed_root(
         &self,
         ancestors: &Ancestors,
@@ -4449,7 +4443,7 @@ impl AccountsDb {
     /// Load account with `pubkey` and maybe put into read cache.
     ///
     /// Return the account and the slot when the account was last stored.
-    /// Return None for default tombstone accounts.
+    /// Return None for cleanable tombstone-like accounts.
     pub fn load_account_with(
         &self,
         ancestors: &Ancestors,
@@ -4464,7 +4458,7 @@ impl AccountsDb {
         if !in_write_cache {
             let result = self.read_only_accounts_cache.load(*pubkey, slot);
             if let Some(account) = result {
-                if is_default_account(&account) {
+                if is_cleanable_zero_lamport_account(&account) {
                     return None;
                 }
                 return Some((account, slot));
@@ -4484,7 +4478,7 @@ impl AccountsDb {
         // since the cache could be flushed in between the 2 calls.
         let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
         let account = account_accessor.check_and_get_loaded_account_shared_data();
-        if is_default_account(&account) {
+        if is_cleanable_zero_lamport_account(&account) {
             return None;
         }
 
@@ -4532,7 +4526,8 @@ impl AccountsDb {
             if !in_write_cache {
                 let result = self.read_only_accounts_cache.load(*pubkey, slot);
                 if let Some(account) = result {
-                    if load_zero_lamports == LoadZeroLamports::None && is_default_account(&account)
+                    if load_zero_lamports == LoadZeroLamports::None
+                        && is_cleanable_zero_lamport_account(&account)
                     {
                         return None;
                     }
@@ -4563,7 +4558,9 @@ impl AccountsDb {
         // since the cache could be flushed in between the 2 calls.
         let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
         let account = account_accessor.check_and_get_loaded_account_shared_data();
-        if load_zero_lamports == LoadZeroLamports::None && is_default_account(&account) {
+        if load_zero_lamports == LoadZeroLamports::None
+            && is_cleanable_zero_lamport_account(&account)
+        {
             return None;
         }
 
@@ -6693,7 +6690,7 @@ impl AccountsDb {
                     let data_len = account.data.len() as u64;
                     let stored_size_aligned =
                         storage.accounts.calculate_stored_size(data_len as usize);
-                    let is_tombstone = is_default_account(&account);
+                    let is_tombstone = is_cleanable_zero_lamport_account(&account);
                     let info = IndexInfo {
                         stored_size_aligned,
                         index_info: IndexInfoInner {
@@ -6718,7 +6715,7 @@ impl AccountsDb {
                         let data_len = account.data_len as u64;
                         let stored_size_aligned =
                             storage.accounts.calculate_stored_size(data_len as usize);
-                        let is_tombstone = is_default_account_meta(
+                        let is_tombstone = is_cleanable_zero_lamport_account_meta(
                             account.lamports,
                             account.data_len,
                             account.owner,
@@ -6890,13 +6887,14 @@ impl AccountsDb {
                                     for (slot2, account_info2) in slot_list.iter() {
                                         if *slot2 == slot {
                                             count += 1;
-                                            let is_tombstone = is_default_account_meta(
-                                                account.lamports,
-                                                account.data_len,
-                                                account.owner,
-                                                account.executable,
-                                                account.rent_epoch,
-                                            );
+                                            let is_tombstone =
+                                                is_cleanable_zero_lamport_account_meta(
+                                                    account.lamports,
+                                                    account.data_len,
+                                                    account.owner,
+                                                    account.executable,
+                                                    account.rent_epoch,
+                                                );
                                             let ai = AccountInfo::new(
                                                 StorageLocation::AppendVec(store_id, offset), // will never be cached
                                                 is_tombstone,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1477,6 +1477,72 @@ fn test_clean_old_with_zero_lamport_account() {
 }
 
 #[test]
+fn test_clean_zero_lamport_system_owner_empty_data() {
+    solana_logger::setup();
+
+    let accounts = AccountsDb::new_single_for_tests();
+    let account_key = solana_pubkey::new_rand();
+
+    let mut zero_system_account =
+        AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id());
+    // Ensure non-default rent still gets cleaned for this class.
+    zero_system_account.set_rent_epoch(42);
+
+    accounts.store_for_tests((0, [(&account_key, &zero_system_account)].as_slice()));
+    accounts.add_root_and_flush_write_cache(0);
+
+    assert!(accounts
+        .accounts_index
+        .contains_with(&account_key, None, None));
+    assert_eq!(accounts.alive_account_count_in_slot(0), 1);
+
+    accounts.clean_accounts_for_tests();
+
+    assert!(!accounts
+        .accounts_index
+        .contains_with(&account_key, None, None));
+    assert_eq!(accounts.alive_account_count_in_slot(0), 0);
+}
+
+#[test]
+fn test_load_hides_cleanable_system_zero_lamport_account_before_clean() {
+    solana_logger::setup();
+
+    let accounts = AccountsDb::new_single_for_tests();
+    let account_key = solana_pubkey::new_rand();
+    let ancestors = Ancestors::default();
+
+    let owner = solana_pubkey::new_rand();
+    let mut initial_account = AccountSharedData::new(10, 3, &owner);
+    initial_account.set_data(vec![1, 2, 3]);
+
+    let zero_system_account =
+        AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id());
+
+    accounts.store_for_tests((0, [(&account_key, &initial_account)].as_slice()));
+    accounts.add_root_and_flush_write_cache(0);
+
+    assert_eq!(
+        accounts
+            .load(&ancestors, &account_key, LoadHint::Unspecified)
+            .unwrap()
+            .0
+            .lamports(),
+        10
+    );
+
+    accounts.store_for_tests((1, [(&account_key, &zero_system_account)].as_slice()));
+    accounts.add_root_and_flush_write_cache(1);
+
+    assert!(accounts.accounts_index.contains_with(&account_key, None, None));
+    assert_eq!(
+        accounts.load(&ancestors, &account_key, LoadHint::Unspecified),
+        None,
+    );
+    assert_eq!(accounts.alive_account_count_in_slot(1), 1);
+}
+
+#[test]
 fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     solana_logger::setup();
 
@@ -1586,19 +1652,17 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
 
     accounts.clean_accounts_for_tests();
 
-    //both zero lamport and normal accounts are cleaned up
+    // Old rooted states are cleaned, but non-tombstone zero-lamport account stays alive.
     assert_eq!(accounts.alive_account_count_in_slot(0), 0);
-    // The only store to slot 1 was a zero lamport account, should
-    // be purged by zero-lamport cleaning logic because slot 1 is
-    // rooted
-    assert_eq!(accounts.alive_account_count_in_slot(1), 0);
+    // Slot 1 contains a zero-lamport account with non-default owner/data,
+    // so it must not be purged as a tombstone.
+    assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     assert_eq!(accounts.alive_account_count_in_slot(2), 1);
 
-    // `pubkey1`, a zero lamport account, should no longer exist in accounts index
-    // because it has been removed by the clean
-    assert!(!accounts.accounts_index.contains_with(&pubkey1, None, None));
+    // `pubkey1` zero-lamport account remains in accounts index.
+    assert!(accounts.accounts_index.contains_with(&pubkey1, None, None));
 
-    // Secondary index should have purged `pubkey1` as well
+    // Secondary index should retain both pubkeys.
     let mut found_accounts = vec![];
     accounts
         .accounts_index
@@ -1610,7 +1674,10 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
             &ScanConfig::default(),
         )
         .unwrap();
-    assert_eq!(found_accounts, vec![pubkey2]);
+    found_accounts.sort();
+    let mut expected_accounts = vec![pubkey1, pubkey2];
+    expected_accounts.sort();
+    assert_eq!(found_accounts, expected_accounts);
 }
 
 #[test]

--- a/accounts-db/src/is_loadable.rs
+++ b/accounts-db/src/is_loadable.rs
@@ -1,4 +1,6 @@
-use {crate::account_utils::is_default_account, solana_account::ReadableAccount};
+use {
+    crate::account_utils::is_cleanable_zero_lamport_account, solana_account::ReadableAccount,
+};
 
 /// A trait to see if an account is loadable or not.
 pub trait IsLoadable {
@@ -8,7 +10,7 @@ pub trait IsLoadable {
 
 impl<T: ReadableAccount> IsLoadable for T {
     fn is_loadable(&self) -> bool {
-        // Treat only default tombstone accounts as non-loadable.
-        !is_default_account(self)
+        // Hide accounts that are cleanable by zero-lamport clean from scan/list paths.
+        !is_cleanable_zero_lamport_account(self)
     }
 }

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -1,8 +1,8 @@
 //! trait for abstracting underlying storage of pubkey and account pairs to be written
 use {
     crate::{
-        account_utils::is_default_account,
         account_storage::stored_account_info::StoredAccountInfo,
+        account_utils::{is_cleanable_zero_lamport_account, is_default_account},
         accounts_db::{AccountFromStorage, AccountStorageEntry, AccountsDb},
         is_zero_lamport::IsZeroLamport,
     },
@@ -118,13 +118,13 @@ pub trait StorableAccounts<'a>: Sync {
     fn data_len(&self, index: usize) -> usize;
     /// pubkey of account at 'index'
     fn pubkey(&self, index: usize) -> &Pubkey;
-    /// true if the account is a tombstone default account
+    /// true if the account is a zero-lamport clean candidate
     fn is_tombstone(&self, index: usize) -> bool {
         if !self.is_zero_lamport(index) {
             return false;
         }
 
-        self.account(index, |account| is_default_account(&account))
+        self.account(index, |account| is_cleanable_zero_lamport_account(&account))
     }
     /// None if account is a tombstone default account
     fn account_default_if_zero_lamport<Ret>(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2515,11 +2515,7 @@ fn get_encoded_account(
     // only used for simulation results
     overwrite_accounts: Option<&HashMap<Pubkey, AccountSharedData>>,
 ) -> Result<Option<UiAccount>> {
-    match account_resolver::get_account_from_overwrites_or_bank_allow_tombstone(
-        pubkey,
-        bank,
-        overwrite_accounts,
-    ) {
+    match account_resolver::get_account_from_overwrites_or_bank(pubkey, bank, overwrite_accounts) {
         Some(account) => {
             let response = if is_known_spl_token_id(account.owner())
                 && encoding == UiAccountEncoding::JsonParsed

--- a/rpc/src/rpc/account_resolver.rs
+++ b/rpc/src/rpc/account_resolver.rs
@@ -12,13 +12,3 @@ pub(crate) fn get_account_from_overwrites_or_bank(
         .and_then(|accounts| accounts.get(pubkey).cloned())
         .or_else(|| bank.get_account(pubkey))
 }
-
-pub(crate) fn get_account_from_overwrites_or_bank_allow_tombstone(
-    pubkey: &Pubkey,
-    bank: &Bank,
-    overwrite_accounts: Option<&HashMap<Pubkey, AccountSharedData>>,
-) -> Option<AccountSharedData> {
-    overwrite_accounts
-        .and_then(|accounts| accounts.get(pubkey).cloned())
-        .or_else(|| bank.get_account_allow_tombstone(pubkey))
-}

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1239,6 +1239,7 @@ pub(crate) mod tests {
             rpc_pubsub_service,
         },
         serial_test::serial,
+        solana_account::WritableAccount,
         solana_commitment_config::CommitmentConfig,
         solana_keypair::Keypair,
         solana_ledger::get_tmp_ledger_path_auto_delete,
@@ -1890,6 +1891,105 @@ pub(crate) mod tests {
                 encoding: UiAccountEncoding::Binary,
                 with_context: false,
             }));
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_program_subscribe_filters_cleanable_system_account() {
+        let GenesisConfigInfo {
+            genesis_config,
+            ..
+        } = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap();
+
+        let live_pubkey = Keypair::new().pubkey();
+        let live_account = AccountSharedData::new(1, 0, &system_program::id());
+        bank1.store_account(&live_pubkey, &live_account);
+
+        let dead_pubkey = Keypair::new().pubkey();
+        let mut dead_account = AccountSharedData::default();
+        dead_account.set_owner(system_program::id());
+        dead_account.set_rent_epoch(u64::MAX - 1);
+        bank1.store_account(&dead_pubkey, &dead_account);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
+        let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
+            exit,
+            max_complete_transaction_status_slot,
+            bank_forks.clone(),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
+            ))),
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
+        ));
+        let (rpc, mut receiver) = rpc_pubsub_service::test_connection(&subscriptions);
+
+        let sub_id = rpc
+            .program_subscribe(
+                system_program::id().to_string(),
+                Some(RpcProgramAccountsConfig {
+                    account_config: RpcAccountInfoConfig {
+                        commitment: Some(CommitmentConfig::processed()),
+                        ..RpcAccountInfoConfig::default()
+                    },
+                    ..RpcProgramAccountsConfig::default()
+                }),
+            )
+            .unwrap();
+
+        subscriptions
+            .control
+            .assert_subscribed(&SubscriptionParams::Program(ProgramSubscriptionParams {
+                pubkey: system_program::id(),
+                filters: Vec::new(),
+                commitment: CommitmentConfig::processed(),
+                data_slice: None,
+                encoding: UiAccountEncoding::Binary,
+                with_context: false,
+            }));
+
+        rpc.block_until_processed(&subscriptions);
+        subscriptions.notify_subscribers(CommitmentSlots {
+            slot: 1,
+            ..CommitmentSlots::default()
+        });
+
+        let response = receiver.recv();
+        let expected = json!({
+           "jsonrpc": "2.0",
+           "method": "programNotification",
+           "params": {
+               "result": {
+                   "context": { "slot": 1 },
+                   "value": {
+                       "account": {
+                          "data": "",
+                          "executable": false,
+                          "lamports": 1,
+                          "owner": "11111111111111111111111111111111",
+                          "rentEpoch": 0,
+                          "space": 0,
+                       },
+                       "pubkey": live_pubkey.to_string(),
+                    },
+               },
+               "subscription": 0,
+           }
+        });
+        assert_eq!(
+            expected,
+            serde_json::from_str::<serde_json::Value>(&response).unwrap(),
+        );
+        let should_err = receiver.recv_timeout(std::time::Duration::from_millis(300));
+        assert!(should_err.is_err(), "unexpected second notification: {should_err:?}");
+
+        rpc.program_unsubscribe(sub_id).unwrap();
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4228,13 +4228,6 @@ impl Bank {
             .map(|(acc, _slot)| acc)
     }
 
-    pub fn get_account_allow_tombstone(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-        self.rc
-            .accounts
-            .load_without_fixed_root_allow_tombstone(&self.ancestors, pubkey)
-            .map(|(acc, _slot)| acc)
-    }
-
     // Hi! leaky abstraction here....
     // use this over get_account() if it's called ONLY from on-chain runtime account
     // processing (i.e. from in-band replay/banking stage; that ensures root is *fixed* while

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3267,6 +3267,45 @@ fn test_bank_get_program_accounts() {
 }
 
 #[test]
+fn test_bank_get_program_accounts_modified_since_parent_filters_cleanable_system_account() {
+    let (genesis_config, _mint_keypair) = create_genesis_config(500);
+    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let bank = Arc::new(new_from_parent(parent));
+
+    let live_pubkey = solana_pubkey::new_rand();
+    let live_account = AccountSharedData::new(1, 0, &solana_sdk_ids::system_program::id());
+    bank.store_account(&live_pubkey, &live_account);
+
+    let dead_pubkey = solana_pubkey::new_rand();
+    let mut dead_account = AccountSharedData::default();
+    dead_account.set_owner(solana_sdk_ids::system_program::id());
+    dead_account.set_rent_epoch(u64::MAX - 1);
+    bank.store_account(&dead_pubkey, &dead_account);
+
+    assert_eq!(
+        bank.get_program_accounts_modified_since_parent(&solana_sdk_ids::system_program::id()),
+        vec![(live_pubkey, live_account)]
+    );
+}
+
+#[test]
+fn test_bank_get_program_accounts_modified_since_parent_keeps_noncleanable_zero_lamport_system_account(
+) {
+    let (genesis_config, _mint_keypair) = create_genesis_config(500);
+    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let bank = Arc::new(new_from_parent(parent));
+
+    let pubkey = solana_pubkey::new_rand();
+    let account = AccountSharedData::new(0, 1, &solana_sdk_ids::system_program::id());
+    bank.store_account(&pubkey, &account);
+
+    assert_eq!(
+        bank.get_program_accounts_modified_since_parent(&solana_sdk_ids::system_program::id()),
+        vec![(pubkey, account)]
+    );
+}
+
+#[test]
 fn test_get_filtered_indexed_accounts_limit_exceeded() {
     let (genesis_config, _mint_keypair) = create_genesis_config(500);
     let mut account_indexes = AccountSecondaryIndexes::default();
@@ -11172,6 +11211,61 @@ fn test_create_zero_lamport_without_clean() {
     with_create_zero_lamport(|_| {
         // just do nothing; this should behave identically with test_create_zero_lamport_with_clean
     });
+}
+
+#[test]
+fn test_system_zero_lamport_empty_account_is_hidden_and_cleaned() {
+    solana_logger::setup();
+
+    let account_key = Pubkey::new_unique();
+    let initial_owner = Pubkey::new_unique();
+    let collector = Pubkey::new_unique();
+
+    let (genesis_config, _mint_keypair) = create_genesis_config_no_tx_fee_no_rent(LAMPORTS_PER_SOL);
+    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+    let bank1 = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, &collector, 1);
+    let mut initial_account = AccountSharedData::new(10, 3, &initial_owner);
+    initial_account.set_data(vec![1, 2, 3]);
+    bank1.store_account(&account_key, &initial_account);
+    bank1.freeze();
+    bank1.squash();
+
+    let bank2 = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, 2);
+    let zero_system_account = AccountSharedData::new(0, 0, &system_program::id());
+    bank2.store_account(&account_key, &zero_system_account);
+
+    assert_eq!(bank2.get_account(&account_key), None);
+    assert!(!bank2
+        .get_all_accounts(false)
+        .unwrap()
+        .iter()
+        .any(|(pubkey, _, _slot)| pubkey == &account_key));
+
+    bank2.freeze();
+    bank2.squash();
+
+    let bank3 = new_bank_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, &collector, 3);
+    bank3.freeze();
+    bank3.squash();
+    bank3.force_flush_accounts_cache();
+
+    assert!(bank3
+        .rc
+        .accounts
+        .accounts_db
+        .accounts_index
+        .contains(&account_key));
+
+    bank3.clean_accounts();
+
+    assert_eq!(bank3.get_account(&account_key), None);
+    assert!(!bank3
+        .rc
+        .accounts
+        .accounts_db
+        .accounts_index
+        .contains(&account_key));
 }
 
 #[test]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -40,12 +40,15 @@ use {
     std::num::{NonZeroU32, Saturating},
 };
 
-fn is_default_account(account: &AccountSharedData) -> bool {
-    account.lamports() == 0
+fn is_deallocated_account(account: &AccountSharedData) -> bool {
+    (account.lamports() == 0
         && account.data().is_empty()
         && !account.executable()
         && account.rent_epoch() == Epoch::default()
-        && account.owner() == &Pubkey::default()
+        && account.owner() == &Pubkey::default())
+        || (account.lamports() == 0
+            && account.data().is_empty()
+            && account.owner() == &solana_sdk_ids::system_program::id())
 }
 
 // Per SIMD-0186, all accounts are assigned a base size of 64 bytes to cover
@@ -270,7 +273,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             // If the account is a default tombstone, treat it as deallocated.
             // We return None so it can be created fresh.
             // We *never* remove accounts, or else we would fetch stale state from accounts-db.
-            let option_account = if is_default_account(account) {
+            let option_account = if is_deallocated_account(account) {
                 None
             } else {
                 Some(account.clone())
@@ -383,7 +386,7 @@ pub fn validate_fee_payer(
     rent: &Rent,
     fee: u64,
 ) -> Result<()> {
-    if is_default_account(payer_account) {
+    if is_deallocated_account(payer_account) {
         error_metrics.account_not_found += 1;
         return Err(TransactionError::AccountNotFound);
     }
@@ -957,6 +960,38 @@ mod tests {
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
+    }
+
+    #[test]
+    fn test_account_loader_treats_system_zero_lamport_empty_account_as_deallocated() {
+        let callbacks = TestCallbacks::default();
+        let mut account_loader: AccountLoader<TestCallbacks> = (&callbacks).into();
+        let account_key = Pubkey::new_unique();
+
+        let mut account = AccountSharedData::default();
+        account.set_owner(system_program::id());
+        account.set_rent_epoch(u64::MAX - 1);
+
+        account_loader.loaded_accounts.insert(account_key, account);
+
+        assert_eq!(account_loader.load_account(&account_key), None);
+    }
+
+    #[test]
+    fn test_account_loader_keeps_non_system_zero_lamport_empty_account_alive() {
+        let callbacks = TestCallbacks::default();
+        let mut account_loader: AccountLoader<TestCallbacks> = (&callbacks).into();
+        let account_key = Pubkey::new_unique();
+
+        let mut account = AccountSharedData::default();
+        account.set_owner(Pubkey::new_unique());
+        account.set_rent_epoch(u64::MAX - 1);
+
+        account_loader
+            .loaded_accounts
+            .insert(account_key, account.clone());
+
+        assert_eq!(account_loader.load_account(&account_key), Some(account));
     }
 
     #[test_case(false; "informal_loaded_size")]


### PR DESCRIPTION
Summary of logic changes:

- Tightened cleanup criteria for zero-lamport accounts.
- Added support for purging accounts where:
    > lamports are 0,
    > data is empty,
    > owner is the System Program.
- Preserved existing fork semantics where non-tombstone zero-lamport accounts (with meaningful owner/state) remain valid and are not removed.
- Updated the related cleanup test expectations to align with current zero-lamport policy.
- Added/updated regression coverage to confirm both scenarios:
    > System-owned empty zero-lamport accounts are cleaned.
    > Non-tombstone zero-lamport accounts are retained.