### PR TITLE
PRS-153 Implement syscalls to work with subaccounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-timings",
  "solana-svm-type-overrides",
+ "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -6916,8 +6917,6 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f885ce7f937871ecb56aadbeaaec963b234a580b7d6ebbdb8fa4249a36f92433"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -11403,6 +11402,7 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
+ "solana-sha256-hasher",
  "solana-signature",
  "solana-system-interface",
  "solana-transaction-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -691,6 +691,7 @@ solana-fee-structure = { path = "neon/solana-sdk/fee-structure" }
 solana-define-syscall = { path = "neon/solana-sdk/define-syscall" }
 solana-program = { path = "neon/solana-sdk/program" }
 solana-system-interface = { path = "neon/solana-sdk/system-interface" }
+solana-account = { path = "neon/solana-sdk/account" }
 solana-account-info = { path = "neon/solana-sdk/account-info" }
 solana-compute-budget-interface = { path = "neon/solana-sdk/compute-budget-interface" }
 solana-packet = { path = "neon/solana-sdk/packet" }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -29,16 +29,12 @@ use {
     std::{
         cmp::Reverse,
         collections::{BinaryHeap, HashMap, HashSet},
-        iter,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc, Mutex,
         },
     },
 };
-
-// Forces single-transaction execution to allow dynamic account loading.
-const GLOBAL_TX_LOCK_KEY: Pubkey = Pubkey::new_from_array([0x42; 32]);
 
 pub type PubkeyAccountSlot = (Pubkey, AccountSharedData, Slot);
 
@@ -59,7 +55,6 @@ impl<'a, T: SVMMessage> TransactionAccountLocksIterator<'a, T> {
             .iter()
             .enumerate()
             .map(|(index, key)| (key, self.transaction.is_writable(index)))
-            .chain(iter::once((&GLOBAL_TX_LOCK_KEY, true)))
     }
 }
 

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -527,7 +527,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         )
         .unwrap();
     invoke_context.push().unwrap();
-    let (_parameter_bytes, regions, account_lengths) = serialize_parameters(
+    let (_parameter_bytes, regions, account_lengths, subaccount_lengths) = serialize_parameters(
         &invoke_context
             .transaction_context
             .get_current_instruction_context()
@@ -546,6 +546,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         &verified_executable,
         regions,
         account_lengths,
+        subaccount_lengths,
         &mut invoke_context,
     );
     let (mut vm, _, _) = vm.unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -173,6 +173,8 @@ impl<'a> EnvironmentConfig<'a> {
 pub struct SyscallContext {
     pub allocator: BpfAllocator,
     pub accounts_metadata: Vec<SerializedAccountMetadata>,
+    pub subaccounts_metadata: Vec<SerializedAccountMetadata>,
+    pub subaccounts_infos: UntypedVmSlice,
     pub trace_log: Vec<[u64; 12]>,
     pub dynamic_cpi_accounts: Vec<DynamicCpiAccount>,
 }
@@ -182,6 +184,14 @@ pub struct DynamicCpiAccount {
     pub index_in_transaction: IndexOfAccount,
     pub is_signer: bool,
     pub is_writable: bool,
+}
+
+/// This is the representation of an array in the VM without a type
+/// Like agave_syscalls::VmVmSlice<T> but without the type parameter.
+#[derive(Default)]
+pub struct UntypedVmSlice {
+    pub vm_data_addr: u64,
+    pub vm_data_len: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -310,7 +320,7 @@ impl<'a> InvokeContext<'a> {
         instruction: Instruction,
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
-        self.prepare_next_instruction(&instruction, signers)?;
+        self.prepare_next_instruction(&instruction, signers, Vec::new())?;
         let mut compute_units_consumed = 0;
         self.process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default())?;
         Ok(())
@@ -322,6 +332,7 @@ impl<'a> InvokeContext<'a> {
         &mut self,
         instruction: &Instruction,
         signers: &[Pubkey],
+        subaccounts: Vec<InstructionAccount>,
     ) -> Result<(), InstructionError> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
         // This algorithm allocates the array on the stack for speed.
@@ -449,6 +460,7 @@ impl<'a> InvokeContext<'a> {
             instruction_accounts,
             transaction_callee_map,
             &instruction.data,
+            subaccounts,
         )?;
         Ok(())
     }
@@ -494,6 +506,7 @@ impl<'a> InvokeContext<'a> {
             instruction_accounts,
             transaction_callee_map,
             instruction.data,
+            Vec::new(),
         )?;
         Ok(())
     }
@@ -1288,7 +1301,7 @@ mod tests {
             metas.clone(),
         );
         invoke_context
-            .prepare_next_instruction(&inner_instruction, &[])
+            .prepare_next_instruction(&inner_instruction, &[], Vec::new())
             .unwrap();
 
         let mut compute_units_consumed = 0;
@@ -1475,13 +1488,13 @@ mod tests {
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(&instruction_1, &[fee_payer.pubkey()])
+            .prepare_next_instruction(&instruction_1, &[fee_payer.pubkey()], Vec::new())
             .unwrap();
         test_case_1(&invoke_context);
 
         invoke_context.transaction_context.push().unwrap();
         invoke_context
-            .prepare_next_instruction(&instruction_2, &[fee_payer.pubkey()])
+            .prepare_next_instruction(&instruction_2, &[fee_payer.pubkey()], Vec::new())
             .unwrap();
         test_case_2(&invoke_context);
     }
@@ -1561,7 +1574,7 @@ mod tests {
         );
 
         invoke_context
-            .prepare_next_instruction(&instruction, &[fee_payer.pubkey()])
+            .prepare_next_instruction(&instruction, &[fee_payer.pubkey()], Vec::new())
             .unwrap();
         let instruction_context = invoke_context
             .transaction_context

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -228,6 +228,7 @@ pub fn serialize_parameters(
         AlignedMemory<HOST_ALIGN>,
         Vec<MemoryRegion>,
         Vec<SerializedAccountMetadata>,
+        Vec<SerializedAccountMetadata>,
     ),
     InstructionError,
 > {
@@ -260,9 +261,26 @@ pub fn serialize_parameters(
         // time it's iterated on.
         .collect::<Vec<_>>();
 
+    let subaccounts = (0..instruction_context.get_number_of_subaccounts())
+        .map(|subaccount_index| {
+            if let Some(index) = instruction_context
+                .is_instruction_subaccount_duplicate(subaccount_index)
+                .unwrap()
+            {
+                SerializeAccount::Duplicate(index)
+            } else {
+                let subaccount = instruction_context
+                    .try_borrow_subaccount(subaccount_index)
+                    .unwrap();
+                SerializeAccount::Account(subaccount_index, subaccount)
+            }
+        })
+        .collect::<Vec<_>>();
+
     if is_loader_deprecated {
         serialize_parameters_unaligned(
             accounts,
+            subaccounts,
             instruction_context.get_instruction_data(),
             &program_id,
             stricter_abi_and_runtime_constraints,
@@ -272,6 +290,7 @@ pub fn serialize_parameters(
     } else {
         serialize_parameters_aligned(
             accounts,
+            subaccounts,
             instruction_context.get_instruction_data(),
             &program_id,
             stricter_abi_and_runtime_constraints,
@@ -287,10 +306,12 @@ pub fn deserialize_parameters(
     account_data_direct_mapping: bool,
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
+    subaccounts_metadata: &[SerializedAccountMetadata],
 ) -> Result<(), InstructionError> {
     let is_loader_deprecated =
         instruction_context.get_program_owner()? == bpf_loader_deprecated::id();
     let account_lengths = accounts_metadata.iter().map(|a| a.original_data_len);
+    let subaccount_lengths = subaccounts_metadata.iter().map(|a| a.original_data_len);
     if is_loader_deprecated {
         deserialize_parameters_unaligned(
             instruction_context,
@@ -306,12 +327,14 @@ pub fn deserialize_parameters(
             account_data_direct_mapping,
             buffer,
             account_lengths,
+            subaccount_lengths,
         )
     }
 }
 
 fn serialize_parameters_unaligned(
     accounts: Vec<SerializeAccount>,
+    _subaccounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
     stricter_abi_and_runtime_constraints: bool,
@@ -321,6 +344,7 @@ fn serialize_parameters_unaligned(
     (
         AlignedMemory<HOST_ALIGN>,
         Vec<MemoryRegion>,
+        Vec<SerializedAccountMetadata>,
         Vec<SerializedAccountMetadata>,
     ),
     InstructionError,
@@ -348,7 +372,9 @@ fn serialize_parameters_unaligned(
     }
     size += size_of::<u64>() // instruction data len
          + instruction_data.len() // instruction data
-         + size_of::<Pubkey>(); // program id
+         + size_of::<Pubkey>() // program id
+         + size_of::<u64>();  // subaccounts len
+    // TODO: add subaccounts serialization
 
     let mut s = Serializer::new(
         size,
@@ -396,9 +422,10 @@ fn serialize_parameters_unaligned(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
+    s.write_all((0u64).to_le_bytes().as_ref()); // subaccounts len - TODO: serialize actual subaccounts
 
     let (mem, regions) = s.finish();
-    Ok((mem, regions, accounts_metadata))
+    Ok((mem, regions, accounts_metadata, Vec::new() /* TODO: subaccounts metadata */))
 }
 
 fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
@@ -465,6 +492,7 @@ fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
 
 fn serialize_parameters_aligned(
     accounts: Vec<SerializeAccount>,
+    subaccounts: Vec<SerializeAccount>,
     instruction_data: &[u8],
     program_id: &Pubkey,
     stricter_abi_and_runtime_constraints: bool,
@@ -475,40 +503,93 @@ fn serialize_parameters_aligned(
         AlignedMemory<HOST_ALIGN>,
         Vec<MemoryRegion>,
         Vec<SerializedAccountMetadata>,
+        Vec<SerializedAccountMetadata>,
     ),
     InstructionError,
 > {
+    fn serialized_size(account: &BorrowedAccount, stricter_abi_and_runtime_constraints: bool, account_data_direct_mapping: bool) -> usize {
+        let data_len = account.get_data().len();
+        size_of::<u8>() // is_signer
+        + size_of::<u8>() // is_writable
+        + size_of::<u8>() // executable
+        + size_of::<u32>() // original_data_len
+        + size_of::<Pubkey>()  // key
+        + size_of::<Pubkey>() // owner
+        + size_of::<u64>()  // lamports
+        + size_of::<u64>()  // data len
+        + size_of::<u64>()  // rent epoch
+        + if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
+            data_len
+                + MAX_PERMITTED_DATA_INCREASE
+                + (data_len as *const u8).align_offset(BPF_ALIGN_OF_U128)
+        } else {
+            BPF_ALIGN_OF_U128
+        }
+    }
+
+    fn serialize_account(
+        s: &mut Serializer,
+        account: &mut BorrowedAccount,
+        mask_out_rent_epoch_in_vm_serialization: bool,
+    ) -> Result<SerializedAccountMetadata, InstructionError> {
+        s.write::<u8>(account.is_signer() as u8);
+        s.write::<u8>(account.is_writable() as u8);
+        #[allow(deprecated)]
+        s.write::<u8>(account.is_executable() as u8);
+        s.write_all(&[0u8, 0, 0, 0]);
+        let vm_key_addr = s.write_all(account.get_key().as_ref());
+        let vm_owner_addr = s.write_all(account.get_owner().as_ref());
+        let vm_lamports_addr = s.write::<u64>(account.get_lamports().to_le());
+        s.write::<u64>((account.get_data().len() as u64).to_le());
+        let vm_data_addr = s.write_account(account)?;
+        let rent_epoch = if mask_out_rent_epoch_in_vm_serialization {
+            u64::MAX
+        } else {
+            account.get_rent_epoch()
+        };
+        s.write::<u64>(rent_epoch.to_le());
+        Ok(SerializedAccountMetadata {
+            original_data_len: account.get_data().len(),
+            vm_key_addr,
+            vm_owner_addr,
+            vm_lamports_addr,
+            vm_data_addr,
+        })
+    }
+
     let mut accounts_metadata = Vec::with_capacity(accounts.len());
+    let mut subaccounts_metadata: Vec<SerializedAccountMetadata> = Vec::with_capacity(subaccounts.len());
     // Calculate size in order to alloc once
     let mut size = size_of::<u64>();
+
     for account in &accounts {
         size += 1; // dup
         match account {
             SerializeAccount::Duplicate(_) => size += 7, // padding to 64-bit aligned
-            SerializeAccount::Account(_, account) => {
-                let data_len = account.get_data().len();
-                size += size_of::<u8>() // is_signer
-                + size_of::<u8>() // is_writable
-                + size_of::<u8>() // executable
-                + size_of::<u32>() // original_data_len
-                + size_of::<Pubkey>()  // key
-                + size_of::<Pubkey>() // owner
-                + size_of::<u64>()  // lamports
-                + size_of::<u64>()  // data len
-                + size_of::<u64>(); // rent epoch
-                if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
-                    size += data_len
-                        + MAX_PERMITTED_DATA_INCREASE
-                        + (data_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
-                } else {
-                    size += BPF_ALIGN_OF_U128;
-                }
-            }
+            SerializeAccount::Account(_, account) => size += serialized_size(
+                account, 
+                stricter_abi_and_runtime_constraints, 
+                account_data_direct_mapping
+            ),
         }
     }
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>(); // program id;
+    + size_of::<Pubkey>() // program id;
+    + (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128)
+    + size_of::<u64>();  // subaccounts len
+
+    for subaccount in &subaccounts {
+        size += 1; // dup
+        match subaccount {
+            SerializeAccount::Duplicate(_) => size += 7, // padding to 64-bit aligned
+            SerializeAccount::Account(_, account) => size += serialized_size(
+                account, 
+                stricter_abi_and_runtime_constraints, 
+                account_data_direct_mapping
+            ),
+        }
+    }
 
     let mut s = Serializer::new(
         size,
@@ -524,29 +605,12 @@ fn serialize_parameters_aligned(
         match account {
             SerializeAccount::Account(_, mut borrowed_account) => {
                 s.write::<u8>(NON_DUP_MARKER);
-                s.write::<u8>(borrowed_account.is_signer() as u8);
-                s.write::<u8>(borrowed_account.is_writable() as u8);
-                #[allow(deprecated)]
-                s.write::<u8>(borrowed_account.is_executable() as u8);
-                s.write_all(&[0u8, 0, 0, 0]);
-                let vm_key_addr = s.write_all(borrowed_account.get_key().as_ref());
-                let vm_owner_addr = s.write_all(borrowed_account.get_owner().as_ref());
-                let vm_lamports_addr = s.write::<u64>(borrowed_account.get_lamports().to_le());
-                s.write::<u64>((borrowed_account.get_data().len() as u64).to_le());
-                let vm_data_addr = s.write_account(&mut borrowed_account)?;
-                let rent_epoch = if mask_out_rent_epoch_in_vm_serialization {
-                    u64::MAX
-                } else {
-                    borrowed_account.get_rent_epoch()
-                };
-                s.write::<u64>(rent_epoch.to_le());
-                accounts_metadata.push(SerializedAccountMetadata {
-                    original_data_len: borrowed_account.get_data().len(),
-                    vm_key_addr,
-                    vm_owner_addr,
-                    vm_lamports_addr,
-                    vm_data_addr,
-                });
+                let metadata = serialize_account(
+                    &mut s,
+                    &mut borrowed_account,
+                    mask_out_rent_epoch_in_vm_serialization,
+                )?;
+                accounts_metadata.push(metadata);
             }
             SerializeAccount::Duplicate(position) => {
                 accounts_metadata.push(accounts_metadata.get(position as usize).unwrap().clone());
@@ -558,18 +622,118 @@ fn serialize_parameters_aligned(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
+    let align_offset = (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    s.fill_write(align_offset, 0)
+        .map_err(|_| InstructionError::InvalidArgument)?;
+
+    s.write_all(subaccounts.len().to_le_bytes().as_ref()); // subaccounts len
+    for subaccount in subaccounts {
+        match subaccount {
+            SerializeAccount::Account(_, mut borrowed_account) => {
+                s.write::<u8>(NON_DUP_MARKER);
+                let metadata = serialize_account(
+                    &mut s,
+                    &mut borrowed_account,
+                    mask_out_rent_epoch_in_vm_serialization,
+                )?;
+                subaccounts_metadata.push(metadata);
+            }
+            SerializeAccount::Duplicate(position) => {
+                subaccounts_metadata.push(subaccounts_metadata.get(position as usize).unwrap().clone());
+                s.write::<u8>(position as u8);
+                s.write_all(&[0u8, 0, 0, 0, 0, 0, 0]);
+            }
+        }
+    }
 
     let (mem, regions) = s.finish();
-    Ok((mem, regions, accounts_metadata))
+    Ok((mem, regions, accounts_metadata, subaccounts_metadata))
 }
 
-fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
+fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>, J: IntoIterator<Item = usize>>(
     instruction_context: &InstructionContext,
     stricter_abi_and_runtime_constraints: bool,
     account_data_direct_mapping: bool,
     buffer: &[u8],
     account_lengths: I,
+    subaccount_lengths: J,
 ) -> Result<(), InstructionError> {
+    fn deserialize_account(
+        stricter_abi_and_runtime_constraints: bool,
+        account_data_direct_mapping: bool,
+        buffer: &[u8],
+        mut start: usize,
+        borrowed_account: &mut BorrowedAccount,
+        pre_len: usize,
+    ) -> Result<usize, InstructionError> {
+        start += size_of::<u8>() // is_signer
+            + size_of::<u8>() // is_writable
+            + size_of::<u8>() // executable
+            + size_of::<u32>() // original_data_len
+            + size_of::<Pubkey>(); // key
+        let owner = buffer
+            .get(start..start + size_of::<Pubkey>())
+            .ok_or(InstructionError::InvalidArgument)?;
+        start += size_of::<Pubkey>(); // owner
+        let lamports = buffer
+            .get(start..start.saturating_add(8))
+            .map(<[u8; 8]>::try_from)
+            .and_then(Result::ok)
+            .map(u64::from_le_bytes)
+            .ok_or(InstructionError::InvalidArgument)?;
+        if borrowed_account.get_lamports() != lamports {
+            borrowed_account.set_lamports(lamports)?;
+        }
+        start += size_of::<u64>(); // lamports
+        let post_len = buffer
+            .get(start..start.saturating_add(8))
+            .map(<[u8; 8]>::try_from)
+            .and_then(Result::ok)
+            .map(u64::from_le_bytes)
+            .ok_or(InstructionError::InvalidArgument)? as usize;
+        start += size_of::<u64>(); // data length
+        if post_len.saturating_sub(pre_len) > MAX_PERMITTED_DATA_INCREASE
+            || post_len > MAX_PERMITTED_DATA_LENGTH as usize
+        {
+            return Err(InstructionError::InvalidRealloc);
+        }
+        if !stricter_abi_and_runtime_constraints {
+            let data = buffer
+                .get(start..start + post_len)
+                .ok_or(InstructionError::InvalidArgument)?;
+            // The redundant check helps to avoid the expensive data comparison if we can
+            match borrowed_account.can_data_be_resized(post_len) {
+                Ok(()) => borrowed_account.set_data_from_slice(data)?,
+                Err(err) if borrowed_account.get_data() != data => return Err(err),
+                _ => {}
+            }
+        } else if !account_data_direct_mapping && borrowed_account.can_data_be_changed().is_ok()
+        {
+            let data = buffer
+                .get(start..start + post_len)
+                .ok_or(InstructionError::InvalidArgument)?;
+            borrowed_account.set_data_from_slice(data)?;
+        } else if borrowed_account.get_data().len() != post_len {
+            borrowed_account.set_data_length(post_len)?;
+        }
+        start += if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
+            let alignment_offset = (pre_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
+            pre_len // data
+                .saturating_add(MAX_PERMITTED_DATA_INCREASE) // realloc padding
+                .saturating_add(alignment_offset)
+        } else {
+            // See Serializer::write_account() as to why we have this
+            BPF_ALIGN_OF_U128
+        };
+        start += size_of::<u64>(); // rent_epoch
+        if borrowed_account.get_owner().to_bytes() != owner {
+            // Change the owner at the end so that we are allowed to change the lamports and data before
+            borrowed_account.set_owner(owner)?;
+        }
+
+        Ok(start)
+    }
+
     let mut start = size_of::<u64>(); // number of accounts
     for (instruction_account_index, pre_len) in (0..instruction_context
         .get_number_of_instruction_accounts())
@@ -583,70 +747,49 @@ fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
         } else {
             let mut borrowed_account =
                 instruction_context.try_borrow_instruction_account(instruction_account_index)?;
-            start += size_of::<u8>() // is_signer
-                + size_of::<u8>() // is_writable
-                + size_of::<u8>() // executable
-                + size_of::<u32>() // original_data_len
-                + size_of::<Pubkey>(); // key
-            let owner = buffer
-                .get(start..start + size_of::<Pubkey>())
-                .ok_or(InstructionError::InvalidArgument)?;
-            start += size_of::<Pubkey>(); // owner
-            let lamports = buffer
-                .get(start..start.saturating_add(8))
-                .map(<[u8; 8]>::try_from)
-                .and_then(Result::ok)
-                .map(u64::from_le_bytes)
-                .ok_or(InstructionError::InvalidArgument)?;
-            if borrowed_account.get_lamports() != lamports {
-                borrowed_account.set_lamports(lamports)?;
-            }
-            start += size_of::<u64>(); // lamports
-            let post_len = buffer
-                .get(start..start.saturating_add(8))
-                .map(<[u8; 8]>::try_from)
-                .and_then(Result::ok)
-                .map(u64::from_le_bytes)
-                .ok_or(InstructionError::InvalidArgument)? as usize;
-            start += size_of::<u64>(); // data length
-            if post_len.saturating_sub(pre_len) > MAX_PERMITTED_DATA_INCREASE
-                || post_len > MAX_PERMITTED_DATA_LENGTH as usize
-            {
-                return Err(InstructionError::InvalidRealloc);
-            }
-            if !stricter_abi_and_runtime_constraints {
-                let data = buffer
-                    .get(start..start + post_len)
-                    .ok_or(InstructionError::InvalidArgument)?;
-                // The redundant check helps to avoid the expensive data comparison if we can
-                match borrowed_account.can_data_be_resized(post_len) {
-                    Ok(()) => borrowed_account.set_data_from_slice(data)?,
-                    Err(err) if borrowed_account.get_data() != data => return Err(err),
-                    _ => {}
-                }
-            } else if !account_data_direct_mapping && borrowed_account.can_data_be_changed().is_ok()
-            {
-                let data = buffer
-                    .get(start..start + post_len)
-                    .ok_or(InstructionError::InvalidArgument)?;
-                borrowed_account.set_data_from_slice(data)?;
-            } else if borrowed_account.get_data().len() != post_len {
-                borrowed_account.set_data_length(post_len)?;
-            }
-            start += if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
-                let alignment_offset = (pre_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
-                pre_len // data
-                    .saturating_add(MAX_PERMITTED_DATA_INCREASE) // realloc padding
-                    .saturating_add(alignment_offset)
-            } else {
-                // See Serializer::write_account() as to why we have this
-                BPF_ALIGN_OF_U128
-            };
-            start += size_of::<u64>(); // rent_epoch
-            if borrowed_account.get_owner().to_bytes() != owner {
-                // Change the owner at the end so that we are allowed to change the lamports and data before
-                borrowed_account.set_owner(owner)?;
-            }
+            start = deserialize_account(
+                stricter_abi_and_runtime_constraints,
+                account_data_direct_mapping,
+                buffer,
+                start,
+                &mut borrowed_account,
+                pre_len,
+            )?;
+        }
+    }
+
+    let instruction_len = buffer
+        .get(start..start.saturating_add(8))
+        .map(<[u8; 8]>::try_from)
+        .and_then(Result::ok)
+        .map(u64::from_le_bytes)
+        .ok_or(InstructionError::InvalidArgument)?;
+
+    start += size_of::<u64>(); // instruction data length
+    start += instruction_len as usize; // instruction data
+    start += size_of::<Pubkey>(); // program id
+    let align_offset = (instruction_len as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    start += align_offset; // padding to align subaccounts metadata
+    start += size_of::<u64>(); // subaccounts len
+
+    for (account_index, pre_len) in (0..instruction_context.get_number_of_subaccounts())
+        .zip(subaccount_lengths.into_iter())
+    {
+        let duplicate = 
+            instruction_context.is_instruction_subaccount_duplicate(account_index)?;
+        start += size_of::<u8>(); // NON_DUP_MARKER
+        if duplicate.is_some() {
+            start += 7; // padding to 64-bit aligned
+        } else {
+            let mut borrowed_account = instruction_context.try_borrow_subaccount(account_index)?;
+            start = deserialize_account(
+                stricter_abi_and_runtime_constraints,
+                account_data_direct_mapping,
+                buffer,
+                start,
+                &mut borrowed_account,
+                pre_len,
+            )?;
         }
     }
     Ok(())
@@ -793,7 +936,7 @@ mod tests {
                     continue;
                 }
 
-                let (mut serialized, regions, _account_lengths) = serialization_result.unwrap();
+                let (mut serialized, regions, _account_lengths, _subaccounts_metadata) = serialization_result.unwrap();
                 let mut serialized_regions = concat_regions(&regions);
                 let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                     deserialize(
@@ -938,7 +1081,7 @@ mod tests {
                 .unwrap();
 
             // check serialize_parameters_aligned
-            let (mut serialized, regions, accounts_metadata) = serialize_parameters(
+            let (mut serialized, regions, accounts_metadata, _subaccounts_metadata) = serialize_parameters(
                 &instruction_context,
                 stricter_abi_and_runtime_constraints,
                 false, // account_data_direct_mapping
@@ -1008,6 +1151,7 @@ mod tests {
                 false, // account_data_direct_mapping
                 serialized.as_slice(),
                 &accounts_metadata,
+                &_subaccounts_metadata,
             )
             .unwrap();
             for (index_in_transaction, (_key, original_account)) in
@@ -1032,7 +1176,7 @@ mod tests {
                 .get_current_instruction_context()
                 .unwrap();
 
-            let (mut serialized, regions, account_lengths) = serialize_parameters(
+            let (mut serialized, regions, account_lengths, _subaccounts_metadata) = serialize_parameters(
                 &instruction_context,
                 stricter_abi_and_runtime_constraints,
                 false, // account_data_direct_mapping
@@ -1080,6 +1224,7 @@ mod tests {
                 false, // account_data_direct_mapping
                 serialized.as_slice(),
                 &account_lengths,
+                &_subaccounts_metadata,
             )
             .unwrap();
             for (index_in_transaction, (_key, original_account)) in
@@ -1199,7 +1344,7 @@ mod tests {
                 .unwrap();
 
             // check serialize_parameters_aligned
-            let (_serialized, regions, _accounts_metadata) = serialize_parameters(
+            let (_serialized, regions, _accounts_metadata, _subaccounts_metadata) = serialize_parameters(
                 &instruction_context,
                 true,
                 false, // account_data_direct_mapping
@@ -1231,7 +1376,7 @@ mod tests {
                 .get_current_instruction_context()
                 .unwrap();
 
-            let (_serialized, regions, _account_lengths) = serialize_parameters(
+            let (_serialized, regions, _account_lengths, _subaccounts_metadata) = serialize_parameters(
                 &instruction_context,
                 true,
                 false, // account_data_direct_mapping

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -131,7 +131,7 @@ pub fn invoke_builtin_function(
     let mask_out_rent_epoch_in_vm_serialization = invoke_context
         .get_feature_set()
         .mask_out_rent_epoch_in_vm_serialization;
-    let (mut parameter_bytes, _regions, _account_lengths) = serialize_parameters(
+    let (mut parameter_bytes, _regions, _account_lengths, _subaccounts_metadata) = serialize_parameters(
         &instruction_context,
         false, // There is no VM so stricter_abi_and_runtime_constraints can not be implemented here
         false, // There is no VM so account_data_direct_mapping can not be implemented here
@@ -269,7 +269,7 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
             .collect::<Vec<_>>();
 
         invoke_context
-            .prepare_next_instruction(instruction, &signers)
+            .prepare_next_instruction(instruction, &signers, Vec::new())
             .unwrap();
 
         // Copy caller's account_info modifications into invoke_context accounts

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -13,7 +13,7 @@ use {
     solana_program_entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     solana_program_runtime::{
         execution_budget::MAX_INSTRUCTION_STACK_DEPTH,
-        invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
+        invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext, UntypedVmSlice},
         loaded_programs::{
             LoadProgramMetrics, ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             ProgramCacheForTxBatch, ProgramRuntimeEnvironment, DELAY_VISIBILITY_SLOT_OFFSET,
@@ -253,6 +253,7 @@ fn create_vm<'a, 'b>(
     program: &'a Executable<InvokeContext<'b>>,
     regions: Vec<MemoryRegion>,
     accounts_metadata: Vec<SerializedAccountMetadata>,
+    subaccounts_metadata: Vec<SerializedAccountMetadata>,
     invoke_context: &'a mut InvokeContext<'b>,
     stack: &mut [u8],
     heap: &mut [u8],
@@ -273,6 +274,8 @@ fn create_vm<'a, 'b>(
     invoke_context.set_syscall_context(SyscallContext {
         allocator: BpfAllocator::new(heap_size as u64),
         accounts_metadata,
+        subaccounts_metadata,
+        subaccounts_infos: UntypedVmSlice::default(),
         trace_log: Vec::new(),
         dynamic_cpi_accounts: Vec::new(),
     })?;
@@ -288,7 +291,7 @@ fn create_vm<'a, 'b>(
 /// Create the SBF virtual machine
 #[macro_export]
 macro_rules! create_vm {
-    ($vm:ident, $program:expr, $regions:expr, $accounts_metadata:expr, $invoke_context:expr $(,)?) => {
+    ($vm:ident, $program:expr, $regions:expr, $accounts_metadata:expr, $subaccounts_metadata:expr, $invoke_context:expr $(,)?) => {
         let invoke_context = &*$invoke_context;
         let stack_size = $program.get_config().stack_size();
         let heap_size = invoke_context.get_compute_budget().heap_size;
@@ -303,6 +306,7 @@ macro_rules! create_vm {
                 $program,
                 $regions,
                 $accounts_metadata,
+                $subaccounts_metadata,
                 $invoke_context,
                 stack
                     .as_slice_mut()
@@ -1483,7 +1487,7 @@ fn execute<'a, 'b: 'a>(
         .mask_out_rent_epoch_in_vm_serialization;
 
     let mut serialize_time = Measure::start("serialize");
-    let (parameter_bytes, regions, accounts_metadata) = serialization::serialize_parameters(
+    let (parameter_bytes, regions, accounts_metadata, subaccounts_metadata) = serialization::serialize_parameters(
         &instruction_context,
         stricter_abi_and_runtime_constraints,
         invoke_context.account_data_direct_mapping,
@@ -1495,6 +1499,7 @@ fn execute<'a, 'b: 'a>(
     // can map to a more specific error
     let account_region_addrs = accounts_metadata
         .iter()
+        .chain(subaccounts_metadata.iter())
         .map(|m| {
             let vm_end = m
                 .vm_data_addr
@@ -1511,7 +1516,7 @@ fn execute<'a, 'b: 'a>(
     let mut create_vm_time = Measure::start("create_vm");
     let execution_result = {
         let compute_meter_prev = invoke_context.get_remaining();
-        create_vm!(vm, executable, regions, accounts_metadata, invoke_context);
+        create_vm!(vm, executable, regions, accounts_metadata, subaccounts_metadata, invoke_context);
         let (mut vm, stack, heap) = match vm {
             Ok(info) => info,
             Err(e) => {
@@ -1655,6 +1660,7 @@ fn execute<'a, 'b: 'a>(
             invoke_context.account_data_direct_mapping,
             parameter_bytes,
             &invoke_context.get_syscall_context()?.accounts_metadata,
+            &invoke_context.get_syscall_context()?.subaccounts_metadata,
         )
     }
 

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -54,6 +54,7 @@ solana-svm-log-collector = { workspace = true }
 solana-svm-measure = { workspace = true }
 solana-svm-timings = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
+solana-system-interface = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["bincode"] }

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -1,22 +1,13 @@
 use {
-    super::*,
-    crate::{translate_inner, translate_slice_inner, translate_type_inner},
-    solana_instruction::Instruction,
-    solana_loader_v3_interface::instruction as bpf_loader_upgradeable,
-    solana_program_runtime::{
+    super::*, crate::{translate_inner, translate_slice_inner, translate_type_inner}, solana_instruction::Instruction, solana_loader_v3_interface::instruction as bpf_loader_upgradeable, solana_program_runtime::{
         invoke_context::SerializedAccountMetadata,
         serialization::{create_memory_region_of_account, modify_memory_region_of_account},
-    },
-    solana_sbpf::ebpf,
-    solana_stable_layout::stable_instruction::StableInstruction,
-    solana_svm_measure::measure::Measure,
-    solana_transaction_context::{
-        BorrowedAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN,
-    },
-    std::mem,
+    }, solana_sbpf::ebpf, solana_stable_layout::stable_instruction::StableInstruction, solana_svm_measure::measure::Measure, solana_transaction_context::{
+        BorrowedAccount, InstructionAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN,
+    }, std::mem
 };
 
-const MAX_CPI_ACCOUNT_INFOS: usize = 256;
+pub(crate) const MAX_CPI_ACCOUNT_INFOS: usize = 256;
 
 fn check_account_info_pointer(
     invoke_context: &InvokeContext,
@@ -66,7 +57,7 @@ fn translate_slice_mut<'a, T>(
 ///
 /// At the start of a CPI, this can be different from the data stored in the
 /// corresponding BorrowedAccount, and needs to be synched.
-struct CallerAccount<'a> {
+pub(crate) struct CallerAccount<'a> {
     lamports: &'a mut u64,
     owner: &'a mut Pubkey,
     // The original data length of the account at the start of the current
@@ -123,7 +114,7 @@ impl<'a> CallerAccount<'a> {
     }
 
     // Create a CallerAccount given an AccountInfo.
-    fn from_account_info(
+    pub(crate) fn from_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &MemoryMapping<'_>,
         check_aligned: bool,
@@ -242,7 +233,7 @@ impl<'a> CallerAccount<'a> {
     }
 
     // Create a CallerAccount given a SolAccountInfo.
-    fn from_sol_account_info(
+    pub(crate) fn from_sol_account_info(
         invoke_context: &InvokeContext,
         memory_mapping: &MemoryMapping<'_>,
         check_aligned: bool,
@@ -349,6 +340,13 @@ trait SyscallInvokeSigned {
         invoke_context: &mut InvokeContext,
         check_aligned: bool,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
+    fn translate_subaccounts<'a>(
+        subaccount_infos_addr: u64,
+        subaccount_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
@@ -378,6 +376,7 @@ declare_builtin_function!(
             signers_seeds_addr,
             signers_seeds_len,
             memory_mapping,
+            Vec::new(),
         )
     }
 );
@@ -462,6 +461,34 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         )
     }
 
+    fn translate_subaccounts<'a>(
+        subaccount_infos_addr: u64,
+        subaccount_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        let (subaccount_infos, subaccount_info_keys) = translate_account_infos(
+            subaccount_infos_addr,
+            subaccount_infos_len,
+            |subaccount_info: &AccountInfo| subaccount_info.key as *const _ as u64,
+            memory_mapping,
+            invoke_context,
+            check_aligned,
+        )?;
+
+        translate_and_update_subaccounts(
+            &subaccount_info_keys,
+            subaccount_infos,
+            subaccount_infos_addr,
+            invoke_context,
+            memory_mapping,
+            check_aligned,
+            CallerAccount::from_account_info,
+        )
+
+    }
+
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
@@ -530,7 +557,7 @@ struct SolAccountMeta {
 /// Rust representation of C's SolAccountInfo
 #[derive(Debug)]
 #[repr(C)]
-struct SolAccountInfo {
+pub(crate) struct SolAccountInfo {
     key_addr: u64,
     lamports_addr: u64,
     data_len: u64,
@@ -559,6 +586,456 @@ struct SolSignerSeedsC {
 }
 
 declare_builtin_function!(
+    SyscallSelfInvokeRust,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        instruction_addr: u64,
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        subaccounts_seeds_addr: u64,
+        subaccounts_seeds_len: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let check_aligned = invoke_context.get_check_aligned();
+
+        let transaction_context = &invoke_context.transaction_context;
+        let instruction_context = transaction_context.get_current_instruction_context()?;
+        let caller_program_id = instruction_context.get_program_key()?;
+        let subaccounts_seeds = SyscallSelfInvokeRust::translate_subaccounts_seeds(
+            caller_program_id,
+            subaccounts_seeds_addr,
+            subaccounts_seeds_len,
+            memory_mapping,
+            check_aligned,
+            invoke_context,
+        )?;
+
+        let mut next_instruction_subaccounts = Vec::with_capacity(subaccounts_seeds.len());
+
+        for (subaccount_pubkey, is_writable) in &subaccounts_seeds {
+            let subaccount_address = subaccount_address(&subaccount_pubkey);
+            let subaccount_index = if let Some(subaccount_index) = invoke_context
+                .transaction_context
+                .find_index_of_subaccount(&subaccount_pubkey)
+            {
+                subaccount_index
+            } else {
+                let (subaccount, _slot) = invoke_context
+                    .get_account_shared_data(&subaccount_address)
+                    .unwrap_or((AccountSharedData::default(), 0));
+
+                let data_len_cost = (subaccount.data().len() as u64)
+                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                    .unwrap_or(u64::MAX);
+                consume_compute_meter(invoke_context, data_len_cost)?;
+
+                let index = invoke_context
+                    .transaction_context
+                    .add_subaccount(*subaccount_pubkey, subaccount)?;
+                index
+            };
+
+            next_instruction_subaccounts.push(
+                InstructionAccount::new_subaccount(subaccount_index, false, *is_writable)
+            );
+        }
+
+        cpi_common::<Self>(
+            invoke_context,
+            instruction_addr,
+            account_infos_addr,
+            account_infos_len,
+            0u64, // signers_addr
+            0u64, // signers_len
+            memory_mapping,
+            next_instruction_subaccounts,
+        )?;
+
+        Ok(SUCCESS)
+    }
+);
+
+impl SyscallInvokeSigned for SyscallSelfInvokeRust {
+    fn translate_instruction(
+        addr: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Instruction, Error> {
+        let instruction = SyscallInvokeSignedC::translate_instruction(addr, memory_mapping, invoke_context, check_aligned)?;
+        let program_id = invoke_context
+            .transaction_context
+            .get_current_instruction_context()?
+            .get_program_key()?;
+        if instruction.program_id != *program_id {
+            return Err(Box::new(SyscallError::InvalidSelfInvokeProgramId));
+        }
+        Ok(instruction)
+    }
+
+    fn translate_accounts<'a>(
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        SyscallInvokeSignedRust::translate_accounts(
+            account_infos_addr,
+            account_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned
+        )
+    }
+
+    fn translate_subaccounts<'a>(
+        subaccount_infos_addr: u64,
+        subaccount_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        SyscallInvokeSignedRust::translate_subaccounts(
+            subaccount_infos_addr,
+            subaccount_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned
+        )
+    }
+
+    fn translate_signers(
+        program_id: &Pubkey,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<Vec<Pubkey>, Error> {
+        SyscallInvokeSignedRust::translate_signers(program_id, signers_seeds_addr, signers_seeds_len, memory_mapping, check_aligned)
+    }
+}
+
+impl SyscallSelfInvokeRust {
+    pub fn translate_subaccount_seeds(
+        program_id: &Pubkey,
+        seeds_addr: u64,
+        seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+        invoke_context: &InvokeContext,
+        instruction_context: &solana_transaction_context::InstructionContext,
+    ) -> Result<(Pubkey, bool), Error> {
+        let untranslated_seeds = translate_slice::<VmSlice<u8>>(
+            memory_mapping,
+            seeds_addr,
+            seeds_len,
+            check_aligned,
+        )?;
+        if untranslated_seeds.len() > MAX_SEEDS {
+            return Err(Box::new(InstructionError::MaxSeedLengthExceeded));
+        }
+        let seeds = untranslated_seeds
+            .iter()
+            .map(|untranslated_seed| {
+                untranslated_seed.translate(memory_mapping, check_aligned)
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        let base_seed: [u8; 32] = (*seeds.get(0).ok_or(InstructionError::InvalidArgument)?)
+            .try_into()
+            .map_err(|_| InstructionError::InvalidArgument)?;
+        let base_pubkey = Pubkey::new_from_array(base_seed);
+        let base_index_in_transaction = invoke_context
+            .transaction_context
+            .find_index_of_account(&base_pubkey)
+            .ok_or(InstructionError::InvalidArgument)?;
+        let base_index_in_instruction = instruction_context
+            .get_index_of_account_in_instruction(base_index_in_transaction)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        let is_writable = instruction_context
+            .is_instruction_account_writable(base_index_in_instruction)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        let (subaccount_pubkey, _) = Pubkey::try_find_program_address(&seeds, program_id)
+            .ok_or_else(|| {
+                ic_msg!(invoke_context, "Unable to find a viable program address bump seed");
+                InstructionError::InvalidSeeds
+            })
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        Ok((subaccount_pubkey, is_writable))
+    }
+
+    fn translate_subaccounts_seeds(
+        program_id: &Pubkey,
+        subaccount_seeds_addr: u64,
+        subaccount_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+        invoke_context: &InvokeContext,
+    ) -> Result<Vec<(Pubkey, bool)>, Error> {
+        let mut subaccounts = Vec::new();
+        if subaccount_seeds_len > 0 {
+            let instruction_context = invoke_context
+                .transaction_context
+                .get_current_instruction_context()?;
+
+            let subaccounts_seeds = translate_slice::<VmSlice<VmSlice<u8>>>(
+                memory_mapping,
+                subaccount_seeds_addr,
+                subaccount_seeds_len,
+                check_aligned,
+            )?;
+            for subaccount_seeds in subaccounts_seeds.iter() {
+                let (subaccount_pubkey, is_writable) = Self::translate_subaccount_seeds(
+                    program_id,
+                    subaccount_seeds.ptr(),
+                    subaccount_seeds.len(),
+                    memory_mapping,
+                    check_aligned,
+                    invoke_context,
+                    &instruction_context,
+                )?;
+                subaccounts.push((subaccount_pubkey, is_writable));
+            }
+            Ok(subaccounts)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+}
+
+declare_builtin_function!(
+    SyscallSelfInvokeC,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        instruction_addr: u64,
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        subaccounts_seeds_addr: u64,
+        subaccounts_seeds_len: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let check_aligned = invoke_context.get_check_aligned();
+
+        let transaction_context = &invoke_context.transaction_context;
+        let instruction_context = transaction_context.get_current_instruction_context()?;
+        let caller_program_id = instruction_context.get_program_key()?;
+        let subaccounts_seeds = SyscallSelfInvokeC::translate_subaccounts_seeds(
+            caller_program_id,
+            subaccounts_seeds_addr,
+            subaccounts_seeds_len,
+            memory_mapping,
+            check_aligned,
+            invoke_context,
+        )?;
+
+        let mut next_instruction_subaccounts = Vec::with_capacity(subaccounts_seeds.len());
+
+        for (subaccount_pubkey, is_writable) in &subaccounts_seeds {
+            let subaccount_address = subaccount_address(&subaccount_pubkey);
+            let subaccount_index = if let Some(subaccount_index) = invoke_context
+                .transaction_context
+                .find_index_of_subaccount(&subaccount_pubkey)
+            {
+                subaccount_index
+            } else {
+                let (subaccount, _slot) = invoke_context
+                    .get_account_shared_data(&subaccount_address)
+                    .unwrap_or((AccountSharedData::default(), 0));
+
+                let data_len_cost = (subaccount.data().len() as u64)
+                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                    .unwrap_or(u64::MAX);
+                consume_compute_meter(invoke_context, data_len_cost)?;
+
+                let index = invoke_context
+                    .transaction_context
+                    .add_subaccount(*subaccount_pubkey, subaccount)?;
+                index
+            };
+
+            next_instruction_subaccounts.push(
+                InstructionAccount::new_subaccount(subaccount_index, false, *is_writable)
+            );
+        }
+
+        cpi_common::<Self>(
+            invoke_context,
+            instruction_addr,
+            account_infos_addr,
+            account_infos_len,
+            0u64, // signers_addr
+            0u64, // signers_len
+            memory_mapping,
+            next_instruction_subaccounts,
+        )?;
+
+        Ok(SUCCESS)
+    }
+);
+
+impl SyscallSelfInvokeC {
+    pub fn translate_subaccount_seeds(
+        program_id: &Pubkey,
+        seeds_addr: u64,
+        seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+        invoke_context: &InvokeContext,
+        instruction_context: &solana_transaction_context::InstructionContext,
+    ) -> Result<(Pubkey, bool), Error> {
+        let seeds = translate_slice::<SolSignerSeedC>(
+            memory_mapping,
+            seeds_addr,
+            seeds_len,
+            check_aligned,
+        )?;
+        if seeds.len() > MAX_SEEDS {
+            return Err(Box::new(InstructionError::MaxSeedLengthExceeded));
+        }
+        let seeds_bytes = seeds
+            .iter()
+            .map(|seed| {
+                translate_slice::<u8>(
+                    memory_mapping,
+                    seed.addr,
+                    seed.len,
+                    check_aligned,
+                )
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        let base_seed: [u8; 32] = (*seeds_bytes.get(0).ok_or(InstructionError::InvalidArgument)?)
+            .try_into()
+            .map_err(|_| InstructionError::InvalidArgument)?;
+        let base_pubkey = Pubkey::new_from_array(base_seed);
+        let base_index_in_transaction = invoke_context
+            .transaction_context
+            .find_index_of_account(&base_pubkey)
+            .ok_or(InstructionError::InvalidArgument)?;
+        let base_index_in_instruction = instruction_context
+            .get_index_of_account_in_instruction(base_index_in_transaction)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        let is_writable = instruction_context
+            .is_instruction_account_writable(base_index_in_instruction)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        let (subaccount_pubkey, _) = Pubkey::try_find_program_address(&seeds_bytes, program_id)
+            .ok_or_else(|| {
+                ic_msg!(invoke_context, "Unable to find a viable program address bump seed");
+                InstructionError::InvalidSeeds
+            })
+            .map_err(|_| InstructionError::InvalidArgument)?;
+
+        Ok((subaccount_pubkey, is_writable))
+    }
+
+    fn translate_subaccounts_seeds(
+        program_id: &Pubkey,
+        subaccount_seeds_addr: u64,
+        subaccount_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+        invoke_context: &InvokeContext,
+    ) -> Result<Vec<(Pubkey, bool)>, Error> {
+        let mut subaccounts = Vec::new();
+        if subaccount_seeds_len > 0 {
+            let instruction_context = invoke_context
+                .transaction_context
+                .get_current_instruction_context()?;
+
+            let subaccounts_seeds = translate_slice::<SolSignerSeedsC>(
+                memory_mapping,
+                subaccount_seeds_addr,
+                subaccount_seeds_len,
+                check_aligned,
+            )?;
+            for subaccount_seeds in subaccounts_seeds.iter() {
+                let (subaccount_pubkey, is_writable) = Self::translate_subaccount_seeds(
+                    program_id,
+                    subaccount_seeds.addr,
+                    subaccount_seeds.len,
+                    memory_mapping,
+                    check_aligned,
+                    invoke_context,
+                    &instruction_context,
+                )?;
+                subaccounts.push((subaccount_pubkey, is_writable));
+            }
+            Ok(subaccounts)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+}
+
+impl SyscallInvokeSigned for SyscallSelfInvokeC {
+    fn translate_instruction(
+        addr: u64,
+        memory_mapping: &MemoryMapping,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Instruction, Error> {
+        let instruction = SyscallInvokeSignedC::translate_instruction(addr, memory_mapping, invoke_context, check_aligned)?;
+        let program_id = invoke_context
+            .transaction_context
+            .get_current_instruction_context()?
+            .get_program_key()?;
+        if instruction.program_id != *program_id {
+            return Err(Box::new(SyscallError::InvalidSelfInvokeProgramId));
+        }
+        Ok(instruction)
+    }
+
+    fn translate_accounts<'a>(
+        account_infos_addr: u64,
+        account_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        SyscallInvokeSignedC::translate_accounts(
+            account_infos_addr,
+            account_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned
+        )
+    }
+
+    fn translate_subaccounts<'a>(
+        subaccount_infos_addr: u64,
+        subaccount_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        SyscallInvokeSignedC::translate_subaccounts(
+            subaccount_infos_addr,
+            subaccount_infos_len,
+            memory_mapping,
+            invoke_context,
+            check_aligned
+        )
+    }
+
+    fn translate_signers(
+        program_id: &Pubkey,
+        signers_seeds_addr: u64,
+        signers_seeds_len: u64,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<Vec<Pubkey>, Error> {
+        SyscallInvokeSignedC::translate_signers(program_id, signers_seeds_addr, signers_seeds_len, memory_mapping, check_aligned)
+    }
+}
+
+
+declare_builtin_function!(
     /// Cross-program invocation called from C
     SyscallInvokeSignedC,
     fn rust(
@@ -578,6 +1055,7 @@ declare_builtin_function!(
             signers_seeds_addr,
             signers_seeds_len,
             memory_mapping,
+            Vec::new(),
         )
     }
 );
@@ -660,6 +1138,33 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
             &account_info_keys,
             account_infos,
             account_infos_addr,
+            invoke_context,
+            memory_mapping,
+            check_aligned,
+            CallerAccount::from_sol_account_info,
+        )
+    }
+
+    fn translate_subaccounts<'a>(
+        subaccount_infos_addr: u64,
+        subaccount_infos_len: u64,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext,
+        check_aligned: bool,
+    ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+        let (subaccount_infos, subaccount_info_keys) = translate_account_infos(
+            subaccount_infos_addr,
+            subaccount_infos_len,
+            |account_info: &SolAccountInfo| account_info.key_addr,
+            memory_mapping,
+            invoke_context,
+            check_aligned,
+        )?;
+
+        translate_and_update_subaccounts(
+            &subaccount_info_keys,
+            subaccount_infos,
+            subaccount_infos_addr,
             invoke_context,
             memory_mapping,
             check_aligned,
@@ -893,6 +1398,103 @@ where
     Ok(accounts)
 }
 
+// Finish translating accounts, build CallerAccount values and update callee
+// accounts in preparation of executing the callee.
+fn translate_and_update_subaccounts<'a, T, F>(
+    _subaccount_info_keys: &[&Pubkey],
+    subaccount_infos: &[T],
+    subaccount_infos_addr: u64,
+    invoke_context: &mut InvokeContext,
+    memory_mapping: &MemoryMapping<'_>,
+    check_aligned: bool,
+    do_translate: F,
+) -> Result<Vec<TranslatedAccount<'a>>, Error>
+where
+    F: Fn(
+        &InvokeContext,
+        &MemoryMapping<'_>,
+        bool,
+        u64,
+        &T,
+        &SerializedAccountMetadata,
+    ) -> Result<CallerAccount<'a>, Error>,
+{
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+
+    let subaccounts_metadata = &invoke_context
+        .get_syscall_context()
+        .unwrap()
+        .subaccounts_metadata;
+
+    let mut subaccounts = Vec::with_capacity(instruction_context.instruction_subaccounts().len());
+
+    let stricter_abi_and_runtime_constraints = invoke_context
+        .get_feature_set()
+        .stricter_abi_and_runtime_constraints;
+
+    for (index_in_caller, instruction_subaccount) in instruction_context.instruction_subaccounts().iter().enumerate() {
+        if instruction_context
+            .is_instruction_subaccount_duplicate(index_in_caller as IndexOfAccount)?
+            .is_some()
+        {
+            continue; // Skip duplicate account
+        }
+        
+        let serialized_metadata = subaccounts_metadata.get(index_in_caller)
+            .ok_or_else(|| {
+                ic_msg!(
+                    invoke_context,
+                    "Internal error: index mismatch for subaccount {}: out of bounds for subaccounts_metadata with length {}",
+                    index_in_caller,
+                    subaccounts_metadata.len(),
+                );
+                Box::new(InstructionError::MissingAccount)
+            })?;
+        let subaccount_info = subaccount_infos
+            .get(index_in_caller)
+            .ok_or_else(|| {
+                ic_msg!(
+                    invoke_context,
+                    "Internal error: Invalid subaccount index {}: out of bounds for subaccount_infos with length {}",
+                    index_in_caller,
+                    subaccount_infos.len(),
+                );
+                Box::new(InstructionError::MissingAccount)
+            })?;
+        let callee_account = instruction_context
+            .try_borrow_subaccount(index_in_caller as IndexOfAccount)?;
+        let caller_account = 
+            do_translate(
+                invoke_context,
+                memory_mapping,
+                check_aligned,
+                subaccount_infos_addr.saturating_add(
+                    (index_in_caller as u64).saturating_mul(mem::size_of::<T>() as u64)
+                ),
+                subaccount_info,
+                serialized_metadata,
+            )?;
+
+        let update_caller = update_callee_account(
+            check_aligned,
+            &caller_account,
+            callee_account,
+            stricter_abi_and_runtime_constraints,
+            invoke_context.account_data_direct_mapping,
+        )?;
+
+        subaccounts.push(TranslatedAccount {
+            index_in_caller: (index_in_caller as IndexOfAccount) | SUBACCOUNT_MARKER,
+            caller_account,
+            update_caller_account_region: instruction_subaccount.is_writable() || update_caller,
+            update_caller_account_info: instruction_subaccount.is_writable(),
+        });
+    }
+
+    Ok(subaccounts)
+}
+
 fn is_dynamic_cpi_account(
     invoke_context: &InvokeContext,
     index_in_transaction: IndexOfAccount,
@@ -988,6 +1590,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
     memory_mapping: &mut MemoryMapping,
+    subaccounts: Vec<InstructionAccount>,
 ) -> Result<u64, Error> {
     let check_aligned = invoke_context.get_check_aligned();
 
@@ -1021,7 +1624,7 @@ fn cpi_common<S: SyscallInvokeSigned>(
         check_aligned,
     )?;
     check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
-    invoke_context.prepare_next_instruction(&instruction, &signers)?;
+    invoke_context.prepare_next_instruction(&instruction, &signers, subaccounts)?;
 
     let mut accounts = S::translate_accounts(
         account_infos_addr,
@@ -1031,11 +1634,25 @@ fn cpi_common<S: SyscallInvokeSigned>(
         check_aligned,
     )?;
 
+    // TODO: translate subaccounts
+    let syscall_context = invoke_context.get_syscall_context()?;
+    let subaccounts_metadata = &syscall_context.subaccounts_metadata;
+    if subaccounts_metadata.len() as u64 != syscall_context.subaccounts_infos.vm_data_len {
+        return Err(Box::new(InstructionError::MissingAccount));
+    }
+
+    let mut subaccounts = S::translate_subaccounts(
+        syscall_context.subaccounts_infos.vm_data_addr,
+        syscall_context.subaccounts_infos.vm_data_len,
+        memory_mapping,
+        invoke_context,
+        check_aligned,
+    )?;
+
     // Process the callee instruction
     let mut compute_units_consumed = 0;
     invoke_context
         .process_instruction(&mut compute_units_consumed, &mut ExecuteTimings::default())?;
-
     // re-bind to please the borrow checker
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -1047,9 +1664,13 @@ fn cpi_common<S: SyscallInvokeSigned>(
         .get_feature_set()
         .stricter_abi_and_runtime_constraints;
 
-    for translate_account in accounts.iter_mut() {
-        let mut callee_account = instruction_context
-            .try_borrow_instruction_account(translate_account.index_in_caller)?;
+    for translate_account in accounts.iter_mut().chain(subaccounts.iter_mut()) {
+        let mut callee_account = if translate_account.index_in_caller & SUBACCOUNT_MARKER != 0 {
+            let subaccount_index = translate_account.index_in_caller & !SUBACCOUNT_MARKER;
+            instruction_context.try_borrow_subaccount(subaccount_index)?
+        } else {
+            instruction_context.try_borrow_instruction_account(translate_account.index_in_caller)?
+        };
         if translate_account.update_caller_account_info {
             update_caller_account(
                 invoke_context,
@@ -1063,9 +1684,13 @@ fn cpi_common<S: SyscallInvokeSigned>(
     }
 
     if stricter_abi_and_runtime_constraints {
-        for translate_account in accounts.iter() {
-            let mut callee_account = instruction_context
-                .try_borrow_instruction_account(translate_account.index_in_caller)?;
+        for translate_account in accounts.iter().chain(subaccounts.iter()) {
+            let mut callee_account = if translate_account.index_in_caller & SUBACCOUNT_MARKER != 0 {
+                let subaccount_index = translate_account.index_in_caller & !SUBACCOUNT_MARKER;
+                instruction_context.try_borrow_subaccount(subaccount_index)?
+            } else {
+                instruction_context.try_borrow_instruction_account(translate_account.index_in_caller)?
+            };
             if translate_account.update_caller_account_region {
                 update_caller_account_region(
                     memory_mapping,
@@ -1149,7 +1774,7 @@ fn update_callee_account(
     Ok(must_update_caller)
 }
 
-fn update_caller_account_region(
+pub(crate) fn update_caller_account_region(
     memory_mapping: &mut MemoryMapping,
     check_aligned: bool,
     caller_account: &CallerAccount,
@@ -1198,7 +1823,7 @@ fn update_caller_account_region(
 // Safety: Once `stricter_abi_and_runtime_constraints` is enabled all fields of [CallerAccount] used
 // in this function should never point inside the address space reserved for
 // accounts (regardless of the current size of an account).
-fn update_caller_account(
+pub(crate) fn update_caller_account(
     invoke_context: &InvokeContext,
     memory_mapping: &MemoryMapping<'_>,
     check_aligned: bool,
@@ -1913,6 +2538,8 @@ mod tests {
             .set_syscall_context(SyscallContext {
                 allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 accounts_metadata: vec![account_metadata],
+                subaccounts_metadata: Vec::new(),
+                subaccounts_infos: UntypedVmSlice::default(),
                 trace_log: Vec::new(),
                 dynamic_cpi_accounts: Vec::new(),
             })

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -1,5 +1,5 @@
 pub use self::{
-    cpi::{SyscallInvokeSignedC, SyscallInvokeSignedRust},
+    cpi::{SyscallInvokeSignedC, SyscallInvokeSignedRust, SyscallSelfInvokeRust, SyscallSelfInvokeC,},
     logging::{
         SyscallLog, SyscallLogBpfComputeUnits, SyscallLogData, SyscallLogPubkey, SyscallLogU64,
     },
@@ -30,7 +30,7 @@ use {
     solana_program_entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     solana_program_runtime::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
-        invoke_context::{DynamicCpiAccount, InvokeContext},
+        invoke_context::{DynamicCpiAccount, InvokeContext, UntypedVmSlice},
         stable_log,
     },
     solana_pubkey::{Pubkey, PubkeyError, MAX_SEEDS, MAX_SEED_LEN, PUBKEY_BYTES},
@@ -44,13 +44,14 @@ use {
     solana_secp256k1_recover::{
         Secp256k1RecoverError, SECP256K1_PUBLIC_KEY_LENGTH, SECP256K1_SIGNATURE_LENGTH,
     },
-    solana_sha256_hasher::Hasher,
+    solana_sha256_hasher::{Hasher, hashv},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_log_collector::{ic_logger_msg, ic_msg},
     solana_svm_timings::ExecuteTimings,
     solana_svm_type_overrides::sync::Arc,
+    solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, program as system_program},
     solana_sysvar::SysvarSerialize,
-    solana_transaction_context::IndexOfAccount,
+    solana_transaction_context::{InstructionAccount, IndexOfAccount, SUBACCOUNT_MARKER},
     std::{
         alloc::Layout,
         marker::PhantomData,
@@ -124,6 +125,10 @@ pub enum SyscallError {
     InvalidPointer,
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,
+    #[error("Invalid self-invoke program ID")]
+    InvalidSelfInvokeProgramId,
+    #[error("Subaccounts are not supported")]
+    SubaccountsNotSupported,
 }
 
 type Error = Box<dyn std::error::Error>;
@@ -455,8 +460,12 @@ pub fn create_program_runtime_environment_v1<'a>(
     result.register_function("sol_get_return_data", SyscallGetReturnData::vm)?;
 
     // Dynamic account loading
+    result.register_function("sol_create_subaccount", SyscallCreateSubaccount::vm)?;
     result.register_function("sol_cpi_load_account", SyscallCpiLoadAccount::vm)?;
     result.register_function("sol_cpi_load_accounts", SyscallCpiLoadAccounts::vm)?;
+    result.register_function("sol_self_invoke_rust", SyscallSelfInvokeRust::vm)?;
+    result.register_function("sol_self_invoke_c", SyscallSelfInvokeC::vm)?;
+    result.register_function("sol_set_subaccount_slice", SyscallSetSubaccountSlice::vm)?;
 
     // Cross-program invocation
     result.register_function("sol_invoke_signed_c", SyscallInvokeSignedC::vm)?;
@@ -1604,6 +1613,243 @@ fn cpi_load_account(
 
     Ok(CpiLoadAccountResult::Success)
 }
+
+fn subaccount_address(pubkey: &Pubkey) -> Pubkey {
+    let subaccount_address = hashv(&[&[1u8], pubkey.as_ref()]);
+    Pubkey::new_from_array(subaccount_address.to_bytes())
+}
+
+declare_builtin_function!(
+    /// Set the subaccounts AccountInfo slice for the current instruction context, this is used to support subaccounts in CPI
+    SyscallSetSubaccountSlice,
+    fn rust (
+        invoke_context: &mut InvokeContext,
+        subaccounts_info_addr: u64,
+        subaccounts_info_len: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let syscall_base_cost = invoke_context
+            .get_execution_cost()
+            .syscall_base_cost;
+        consume_compute_meter(invoke_context, syscall_base_cost)?;
+
+        let subaccounts_info = translate_slice::<VmSlice<AccountInfo>>(
+            memory_mapping,
+            subaccounts_info_addr,
+            subaccounts_info_len,
+            invoke_context.get_check_aligned(),
+        )?;
+
+        if subaccounts_info.len() > crate::cpi::MAX_CPI_ACCOUNT_INFOS {
+            return Err(InstructionError::MaxAccountsExceeded.into());
+        }
+
+        let syscall_context = invoke_context.get_syscall_context_mut()?;
+        syscall_context.subaccounts_infos = UntypedVmSlice {
+            vm_data_addr: subaccounts_info_addr,
+            vm_data_len: subaccounts_info_len,
+        };
+
+        Ok(SUCCESS)
+    }
+);
+
+declare_builtin_function!(
+    /// Create subaccount
+    SyscallCreateSubaccount,
+    fn rust (
+        invoke_context: &mut InvokeContext,
+        _payer_pubkey_addr: u64,
+        seeds_addr: u64,
+        seeds_len: u64,
+        space: u64,
+        lamports: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        let syscall_base_cost = invoke_context
+            .get_execution_cost()
+            .syscall_base_cost;
+        consume_compute_meter(invoke_context, syscall_base_cost)?;
+        let check_aligned = invoke_context.get_check_aligned();
+
+        let (program_id, subaccount_pubkey) = {
+            let instruction_context = invoke_context
+                .transaction_context
+                .get_current_instruction_context()?;
+            let program_id = *instruction_context.get_program_key()?;
+            let (subaccount_pubkey, is_writable) = SyscallSelfInvokeRust::translate_subaccount_seeds(
+                &program_id,
+                seeds_addr,
+                seeds_len,
+                memory_mapping,
+                check_aligned,
+                invoke_context,
+                &instruction_context,
+            )?;
+
+            if !is_writable {
+                return Err(InstructionError::ReadonlyDataModified.into());
+            }
+
+            (program_id, subaccount_pubkey)
+        };
+
+        let subaccount_address = subaccount_address(&subaccount_pubkey);
+        let subaccount_index = if let Some(subaccount_index) = invoke_context
+            .transaction_context
+            .find_index_of_subaccount(&subaccount_pubkey)
+        {
+            subaccount_index
+        } else {
+            let (subaccount, _slot) = invoke_context
+                .get_account_shared_data(&subaccount_address)
+                .unwrap_or((AccountSharedData::default(), 0));
+
+            let data_len_cost = (subaccount.data().len() as u64)
+                .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                .unwrap_or(u64::MAX);
+            consume_compute_meter(invoke_context, data_len_cost)?;
+
+            invoke_context
+                .transaction_context
+                .add_subaccount(subaccount_pubkey, subaccount)?
+        };
+
+        let system_program_index = invoke_context
+            .transaction_context
+            .find_index_of_account(&system_program::id())
+            .ok_or(InstructionError::MissingAccount)?;
+
+        invoke_context.transaction_context.configure_next_instruction(
+            system_program_index,
+            Vec::new(),
+            Vec::new(),
+            &[],
+            vec![
+                InstructionAccount::new_subaccount(subaccount_index, false, true),
+            ],
+        )?;
+        invoke_context.transaction_context.push()?;
+        {
+            // Do stuff to create subaccount
+            let instruction_context = invoke_context.transaction_context
+                .get_current_instruction_context()?;
+            let mut subaccount = instruction_context
+                .try_borrow_subaccount(0)?;
+
+            // if it looks like the `to` subaccount is already in use, bail
+            //   (note that the id check is also enforced by message_processor)
+            if !subaccount.get_data().is_empty() || !system_program::check_id(subaccount.get_owner()) {
+                ic_msg!(
+                    invoke_context,
+                    "Allocate: subaccount {:?} already in use",
+                    subaccount_pubkey,
+                );
+                return Err(InstructionError::AccountAlreadyInitialized.into());
+            }
+
+            if space > MAX_PERMITTED_DATA_LENGTH {
+                ic_msg!(
+                    invoke_context,
+                    "Allocate: requested {}, max allowed {}",
+                    space,
+                    MAX_PERMITTED_DATA_LENGTH
+                );
+                return Err(InstructionError::InvalidArgument.into());
+            }
+
+            subaccount.set_data_length(space as usize)?;
+            subaccount.set_owner(&program_id.to_bytes())?;
+        }
+        invoke_context.transaction_context.pop()?;
+
+        if lamports > 0 {
+            // TODO: Do a transfer from the payer to the subaccount to fund it
+        }
+
+        // Mark this account as subaccount
+        use solana_account::WritableAccount;
+        invoke_context
+            .transaction_context
+            .accounts()
+            .try_borrow_mut_subaccount(subaccount_index)?
+            .set_subaccount_mark();
+
+        // Sync the subaccount with AccountInfo if it loaded
+        let instruction_context = invoke_context
+            .transaction_context
+            .get_current_instruction_context()?;
+        let position = instruction_context.instruction_subaccounts()
+            .iter()
+            .position(|account| account.index_in_transaction == subaccount_index | SUBACCOUNT_MARKER);
+        if let Some(position) = position {
+            let stricter_abi_and_runtime_constraints = invoke_context
+                .get_feature_set()
+                .stricter_abi_and_runtime_constraints;
+
+            let syscall_context = invoke_context.get_syscall_context()?;
+            let subaccount_infos = translate_slice::<crate::cpi::SolAccountInfo>(   // TODO: Create special version for C/rust subaccounts
+                memory_mapping,
+                syscall_context.subaccounts_infos.vm_data_addr,
+                syscall_context.subaccounts_infos.vm_data_len,
+                check_aligned,
+            )?;
+            let subaccount_info = subaccount_infos
+                .get(position)
+                .ok_or_else(|| {
+                    ic_msg!(invoke_context, "InstructionError: missing AccountInfo for subaccount");
+                    InstructionError::MissingAccount
+                })?;
+            
+            // TODO: Create special version for C/rust subaccounts
+            let mut caller_account = crate::cpi::CallerAccount::from_sol_account_info(
+                invoke_context,
+                memory_mapping,
+                check_aligned,
+                syscall_context
+                    .subaccounts_infos
+                    .vm_data_addr
+                    .checked_add((position * size_of::<crate::cpi::SolAccountInfo>()) as u64)
+                    .ok_or(SyscallError::ArithmeticOverflow)?,
+                subaccount_info,
+                &syscall_context.subaccounts_metadata[position],
+            )?;
+
+            let mut subaccount = instruction_context
+                .try_borrow_subaccount(position as IndexOfAccount)?;
+
+            crate::cpi::update_caller_account(
+                invoke_context,
+                memory_mapping,
+                check_aligned,
+                &mut caller_account,
+                &mut subaccount,
+                stricter_abi_and_runtime_constraints,
+            )?;
+            crate::cpi::update_caller_account_region(
+                memory_mapping,
+                check_aligned,
+                &caller_account,
+                &mut subaccount,
+                invoke_context.account_data_direct_mapping,
+            )?;
+        }
+
+        // ic_msg!(
+        //     invoke_context,
+        //     "create_subaccount: base_pubkey={} subaccount={} address={} seeds={:?}",
+        //     base_pubkey,
+        //     subaccount_pubkey,
+        //     subaccount_address,
+        //     seeds
+        // );
+
+        Ok(SUCCESS)
+    }
+);
 
 declare_builtin_function!(
     /// Load an account into the transaction context for CPI usage

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -34,6 +34,7 @@ bincode = { workspace = true, optional = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, optional = true }
+solana-sha256-hasher = { workspace = true }
 
 [dev-dependencies]
 solana-account-info = { workspace = true }

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -54,6 +54,7 @@ static_assertions::const_assert_eq!(
 
 /// Index of an account inside of the transaction or an instruction.
 pub type IndexOfAccount = u16;
+pub const SUBACCOUNT_MARKER: u16 = 1 << 15;
 
 /// Contains account meta data which varies between instruction.
 ///
@@ -85,6 +86,18 @@ impl InstructionAccount {
         }
     }
 
+    pub fn new_subaccount(
+        index_in_transaction: IndexOfAccount,
+        is_signer: bool,
+        is_writable: bool,
+    ) -> InstructionAccount {
+        InstructionAccount {
+            index_in_transaction: index_in_transaction | SUBACCOUNT_MARKER,
+            is_signer: is_signer as u8,
+            is_writable: is_writable as u8,
+        }
+    }
+
     pub fn is_signer(&self) -> bool {
         self.is_signer != 0
     }
@@ -109,7 +122,9 @@ pub type TransactionAccount = (Pubkey, AccountSharedData);
 pub struct TransactionAccounts {
     #[allow(clippy::vec_box)]
     accounts: RefCell<Vec<Box<RefCell<AccountSharedData>>>>,
+    subaccounts: RefCell<Vec<Box<RefCell<AccountSharedData>>>>,
     touched_flags: RefCell<Vec<bool>>,
+    touched_subaccounts: RefCell<Vec<bool>>,
     resize_delta: Cell<i64>,
     lamports_delta: Cell<i128>,
     dynamic_accounts_lamports_sum: Cell<u128>,
@@ -123,6 +138,8 @@ impl TransactionAccounts {
         TransactionAccounts {
             accounts: RefCell::new(accounts),
             touched_flags: RefCell::new(touched_flags),
+            subaccounts: RefCell::new(Vec::new()),
+            touched_subaccounts: RefCell::new(Vec::new()),
             resize_delta: Cell::new(0),
             lamports_delta: Cell::new(0),
             dynamic_accounts_lamports_sum: Cell::new(0),
@@ -135,11 +152,20 @@ impl TransactionAccounts {
 
     #[cfg(not(target_os = "solana"))]
     pub fn touch(&self, index: IndexOfAccount) -> Result<(), InstructionError> {
-        *self
-            .touched_flags
-            .borrow_mut()
-            .get_mut(index as usize)
-            .ok_or(InstructionError::NotEnoughAccountKeys)? = true;
+        if index & SUBACCOUNT_MARKER != 0 {
+            let subaccount_index = index & !SUBACCOUNT_MARKER;
+            *self
+                .touched_subaccounts
+                .borrow_mut()
+                .get_mut(subaccount_index as usize)
+                .ok_or(InstructionError::NotEnoughAccountKeys)? = true;
+        } else {
+            *self
+                .touched_flags
+                .borrow_mut()
+                .get_mut(index as usize)
+                .ok_or(InstructionError::NotEnoughAccountKeys)? = true;
+        }
         Ok(())
     }
 
@@ -201,6 +227,51 @@ impl TransactionAccounts {
             .map_err(|_| InstructionError::AccountBorrowFailed)
     }
 
+    fn _try_borrow_subaccount(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<*const RefCell<AccountSharedData>, InstructionError> {
+        let subaccounts = self.subaccounts.borrow();
+        let account_cell = subaccounts
+            .get(index as usize)
+            .ok_or(InstructionError::MissingAccount)?;
+        let account_ptr: *const RefCell<AccountSharedData> = &**account_cell;
+        Ok(account_ptr)
+        // drop(subaccounts);
+        // // Safe: the subaccount is boxed, so its address is stable even if the vec moves.
+        // unsafe { (*account_ptr).try_borrow() }
+        //     .map_err(|_| InstructionError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow_subaccount(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<Ref<'_, AccountSharedData>, InstructionError> {
+        // let subaccounts = self.subaccounts.borrow();
+        // let account_cell = subaccounts
+        //     .get(index as usize)
+        //     .ok_or(InstructionError::MissingAccount)?;
+        // let account_ptr: *const RefCell<AccountSharedData> = &**account_cell;
+        // drop(subaccounts);
+
+        // We need to keep the RefCell borrow alive while we use the pointer.
+        let account_ptr = self._try_borrow_subaccount(index)?;
+        // Safe: the subaccount is boxed, so its address is stable even if the vec moves.
+        unsafe { (*account_ptr).try_borrow() }
+            .map_err(|_| InstructionError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow_mut_subaccount(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<RefMut<'_, AccountSharedData>, InstructionError> {
+        // We need to keep the RefCell borrow alive while we use the pointer.
+        let account_ptr = self._try_borrow_subaccount(index)?;
+        // Safe: the subaccount is boxed, so its address is stable even if the vec moves.
+        unsafe { (*account_ptr).try_borrow_mut() }
+            .map_err(|_| InstructionError::AccountBorrowFailed)
+    }
+
     fn add_lamports_delta(&self, balance: i128) -> Result<(), InstructionError> {
         let delta = self.lamports_delta.get();
         self.lamports_delta.set(
@@ -230,6 +301,18 @@ impl TransactionAccounts {
             .set(self.dynamic_accounts_lamports_sum.get().saturating_add(lamports as u128));
         index
     }
+
+    #[cfg(not(target_os = "solana"))]
+    fn add_subaccount(&self, account: AccountSharedData) -> IndexOfAccount {
+        let lamports = account.lamports();
+        let mut subaccounts = self.subaccounts.borrow_mut();
+        let index = subaccounts.len() as IndexOfAccount;
+        subaccounts.push(Box::new(RefCell::new(account)));
+        self.touched_subaccounts.borrow_mut().push(false);
+        self.dynamic_accounts_lamports_sum
+            .set(self.dynamic_accounts_lamports_sum.get().saturating_add(lamports as u128));
+        index
+    }
 }
 
 /// Loaded transaction shared between runtime and programs.
@@ -238,6 +321,7 @@ impl TransactionAccounts {
 #[derive(Debug)]
 pub struct TransactionContext {
     account_keys: Vec<Pubkey>,
+    subaccount_keys: Vec<Pubkey>,
     accounts: Rc<TransactionAccounts>,
     instruction_stack_capacity: usize,
     instruction_trace_capacity: usize,
@@ -264,6 +348,7 @@ impl TransactionContext {
             .unzip();
         Self {
             account_keys,
+            subaccount_keys: Vec::new(),
             accounts: Rc::new(TransactionAccounts::new(accounts)),
             instruction_stack_capacity,
             instruction_trace_capacity,
@@ -311,9 +396,17 @@ impl TransactionContext {
         &self,
         index_in_transaction: IndexOfAccount,
     ) -> Result<&Pubkey, InstructionError> {
-        self.account_keys
-            .get(index_in_transaction as usize)
-            .ok_or(InstructionError::NotEnoughAccountKeys)
+        if index_in_transaction & SUBACCOUNT_MARKER != 0 {
+            let subaccount_index = index_in_transaction & !SUBACCOUNT_MARKER;
+            self
+                .subaccount_keys
+                .get(subaccount_index as usize)
+                .ok_or(InstructionError::NotEnoughAccountKeys)
+        } else {
+            self.account_keys
+                .get(index_in_transaction as usize)
+                .ok_or(InstructionError::NotEnoughAccountKeys)
+        }
     }
 
     /// Searches for an account by its key
@@ -322,6 +415,31 @@ impl TransactionContext {
             .iter()
             .position(|key| key == pubkey)
             .map(|index| index as IndexOfAccount)
+    }
+
+    /// Searches for an subaccount keys
+    pub fn find_index_of_subaccount(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
+        self.subaccount_keys
+            .iter()
+            .position(|key| key == pubkey)
+            .map(|index| index as IndexOfAccount)
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    pub fn add_subaccount(
+        &mut self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> Result<IndexOfAccount, InstructionError> {
+        if let Some(_index) = self.find_index_of_subaccount(&pubkey) {
+            return Err(InstructionError::DuplicateAccountIndex);
+        }
+        if self.subaccount_keys.len() >= MAX_ACCOUNTS_PER_TRANSACTION {
+            return Err(InstructionError::MaxAccountsExceeded);
+        }
+        let index = self.accounts.add_subaccount(account);
+        self.subaccount_keys.push(pubkey);
+        Ok(index)
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -372,6 +490,8 @@ impl TransactionContext {
             instruction_accounts: &instruction.instruction_accounts,
             dedup_map: &instruction.dedup_map,
             instruction_data: &instruction.instruction_data,
+            subaccounts: &instruction.subaccounts,
+            dedup_subaccounts: &instruction.dedup_subaccounts,
         })
     }
 
@@ -430,8 +550,27 @@ impl TransactionContext {
         instruction_accounts: Vec<InstructionAccount>,
         deduplication_map: Vec<u8>,
         instruction_data: &[u8],
+        subaccounts: Vec<InstructionAccount>,
     ) -> Result<(), InstructionError> {
         debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
+
+        if subaccounts.len() > MAX_ACCOUNTS_PER_INSTRUCTION {
+            return Err(InstructionError::MissingAccount);
+        }
+        let mut dedup_subaccounts = vec![u8::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+        for (position, subaccount) in subaccounts.iter().enumerate() {
+            let index_in_transaction = subaccount.index_in_transaction & !SUBACCOUNT_MARKER;
+            if index_in_transaction as usize >= self.subaccount_keys.len() {
+                return Err(InstructionError::MissingAccount);
+            }
+            let subaccount_position = dedup_subaccounts
+                .get_mut(index_in_transaction as usize)
+                .ok_or(InstructionError::MissingAccount)?;
+            if *subaccount_position == u8::MAX {
+                *subaccount_position = position as u8;
+            }
+        }
+        
         let instruction = self
             .instruction_trace
             .last_mut()
@@ -440,6 +579,8 @@ impl TransactionContext {
         instruction.instruction_accounts = instruction_accounts;
         instruction.instruction_data = instruction_data.to_vec();
         instruction.dedup_map = deduplication_map;
+        instruction.subaccounts = subaccounts;
+        instruction.dedup_subaccounts = dedup_subaccounts;
         Ok(())
     }
 
@@ -464,6 +605,7 @@ impl TransactionContext {
             instruction_accounts,
             dedup_map,
             instruction_data,
+            Vec::new(),
         )
     }
 
@@ -635,9 +777,19 @@ impl TransactionContext {
                 // The four calls below can't really fail. If they fail because of a bug,
                 // whatever is writing will trigger an EbpfError::AccessViolation like
                 // if the region was readonly, and the transaction will fail gracefully.
-                let Ok(mut account) = accounts.try_borrow_mut(index_in_transaction) else {
-                    debug_assert!(false);
-                    return;
+                let mut account = if index_in_transaction & SUBACCOUNT_MARKER != 0 {
+                    let subaccount_index = index_in_transaction & !SUBACCOUNT_MARKER;
+                    let Ok(account) =  accounts.try_borrow_mut_subaccount(subaccount_index) else {
+                        debug_assert!(false);
+                        return;
+                    };
+                    account
+                } else {
+                    let Ok(account) = accounts.try_borrow_mut(index_in_transaction) else {
+                        debug_assert!(false);
+                        return;
+                    };
+                    account
                 };
                 if accounts.touch(index_in_transaction).is_err() {
                     debug_assert!(false);
@@ -700,6 +852,8 @@ pub struct InstructionFrame {
     /// This is a vector of u8s to save memory, since many entries may be unused.
     dedup_map: Vec<u8>,
     instruction_data: Vec<u8>,
+    subaccounts: Vec<InstructionAccount>,
+    dedup_subaccounts: Vec<u8>,
 }
 
 /// View interface to read instructions.
@@ -712,6 +866,8 @@ pub struct InstructionContext<'a> {
     instruction_accounts: &'a [InstructionAccount],
     dedup_map: &'a [u8],
     instruction_data: &'a [u8],
+    subaccounts: &'a [InstructionAccount],
+    dedup_subaccounts: &'a [u8],
 }
 
 impl<'a> InstructionContext<'a> {
@@ -725,6 +881,11 @@ impl<'a> InstructionContext<'a> {
     /// Number of accounts in this Instruction (without program accounts)
     pub fn get_number_of_instruction_accounts(&self) -> IndexOfAccount {
         self.instruction_accounts.len() as IndexOfAccount
+    }
+
+    /// Number of subaccounts in this Instruction
+    pub fn get_number_of_subaccounts(&self) -> IndexOfAccount {
+        self.subaccounts.len() as IndexOfAccount
     }
 
     /// Assert that enough accounts were supplied to this Instruction
@@ -821,6 +982,38 @@ impl<'a> InstructionContext<'a> {
         )
     }
 
+    /// Returns `Some(instruction_subaccount_index)` if this is a duplicate
+    /// and `None` if it is the first subaccount with this key
+    pub fn is_instruction_subaccount_duplicate(
+        &self,
+        instruction_subaccount_index: IndexOfAccount,
+    ) -> Result<Option<IndexOfAccount>, InstructionError> {
+        let index_in_transaction = self
+            .subaccounts
+            .get(instruction_subaccount_index as usize)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .index_in_transaction;
+
+        let first_instruction_subaccount_index = self.dedup_subaccounts
+            .get((index_in_transaction & !SUBACCOUNT_MARKER) as usize)
+            .and_then(|idx| {
+                if *idx as usize >= self.subaccounts.len() {
+                    None
+                } else {
+                    Some(*idx as IndexOfAccount)
+                }
+            })
+            .ok_or(InstructionError::MissingAccount)?;
+
+        Ok(
+            if first_instruction_subaccount_index == instruction_subaccount_index {
+                None
+            } else {
+                Some(first_instruction_subaccount_index)
+            },
+        )
+    }
+
     /// Gets the key of the last program account of this Instruction
     pub fn get_program_key(&self) -> Result<&'a Pubkey, InstructionError> {
         self.get_index_of_program_account_in_transaction()
@@ -860,6 +1053,28 @@ impl<'a> InstructionContext<'a> {
             transaction_context: self.transaction_context,
             instruction_account,
             account,
+            index_in_transaction_of_instruction_program: self.program_account_index_in_tx,
+        })
+    }
+
+    pub fn try_borrow_subaccount(
+        &self,
+        index_in_instruction: IndexOfAccount,
+    ) -> Result<BorrowedAccount, InstructionError> {
+        let instruction_account = *self
+            .subaccounts
+            .get(index_in_instruction as usize)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?;
+
+        let subaccount = self
+            .transaction_context
+            .accounts
+            .try_borrow_mut_subaccount(instruction_account.index_in_transaction & !SUBACCOUNT_MARKER)?;
+
+        Ok(BorrowedAccount {
+            transaction_context: self.transaction_context,
+            instruction_account: instruction_account,
+            account: subaccount,
             index_in_transaction_of_instruction_program: self.program_account_index_in_tx,
         })
     }
@@ -905,6 +1120,10 @@ impl<'a> InstructionContext<'a> {
 
     pub fn instruction_accounts(&self) -> &[InstructionAccount] {
         self.instruction_accounts
+    }
+
+    pub fn instruction_subaccounts(&self) -> &[InstructionAccount] {
+        self.subaccounts
     }
 
     pub fn get_key_of_instruction_account(
@@ -1266,19 +1485,54 @@ impl From<TransactionContext> for ExecutionRecord {
     fn from(context: TransactionContext) -> Self {
         let TransactionAccounts {
             accounts,
+            subaccounts,
             touched_flags,
+            touched_subaccounts,
             resize_delta,
             ..
         } = Rc::try_unwrap(context.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs");
-        let accounts = context
+        let mut accounts: Vec<_> = context
             .account_keys
             .into_iter()
-            .zip(accounts.into_inner().into_iter().map(|account| RefCell::into_inner(*account)))
+            .zip(
+                accounts
+                .into_inner()
+                .into_iter()
+                .map(
+                    |account| RefCell::into_inner(*account)
+                )
+            )
             .collect();
+        let subaccounts = context
+            .subaccount_keys
+            .into_iter()
+            .map(|key| {
+                // TODO: use function subaccount_address instead of inlining the logic here
+                // map subaccounts keys to their corresponding addresses using the same logic as subaccount_address function
+                let address = solana_sha256_hasher::hashv(&[&[1], key.as_ref()]);
+                Pubkey::new_from_array(address.to_bytes())
+            })
+            // .map(|key| {   // map subaccounts keys to their corresponding addresses (do not need because the subaccount_keys contains already translated addresses)
+            //     let address = solana_sha256_hasher::hashv(&[&[1], key.as_ref()]);   // TODO: use subaccount_address function
+            //     Pubkey::new_from_array(address.to_bytes())
+            // })
+            .zip(
+                subaccounts
+                .into_inner()
+                .into_iter()
+                .map(
+                    |subaccount| RefCell::into_inner(*subaccount)
+                )
+            )
+            .collect::<Vec<_>>();
+        accounts.extend(subaccounts);
+
+        // TODO: update touched_account_count & accounts_resize_delta with subaccounts
         let touched_account_count = touched_flags
             .borrow()
             .iter()
+            .chain(touched_subaccounts.borrow().iter())
             .fold(0usize, |accumulator, was_touched| {
                 accumulator.saturating_add(*was_touched as usize)
             }) as u64;


### PR DESCRIPTION
Add VM integration and syscalls for subaccount support:

- Serialize subaccounts into the VM_INPUT section
- Add synchronization between in-memory subaccounts and AccountSharedData
- Introduce new syscalls:
  - sol_create_subaccount
  - sol_self_invoke
  - self_set_subaccount_slice

**Implementation Notes**
- Subaccounts are stored in AccountsDB under addresses derived via subaccount_address (`hashv([[1u8], pubkey])`)
- During transaction execution, subaccounts and regular accounts are treated as two independent sets

These changes enable runtime-level support for subaccounts, ensuring consistency between VM state and account storage, and exposing required functionality via syscalls.