### PR TITLE
expose mempool size as Prometheus gauge

### DIFF
--- a/metrics/src/custom_metrics.rs
+++ b/metrics/src/custom_metrics.rs
@@ -452,6 +452,26 @@ pub fn clear_tx_acceptance_time(signature: &Signature) {
     }
 }
 
+/// Pre-initialize all tx_type label series so they appear in Prometheus
+/// with value 0 even before any matching transaction arrives.
+pub fn init_tx_type_series(labels: &[&str]) {
+    let m = &*CUSTOM_METRICS;
+    for label in labels {
+        let label = &*m.bounded_tx_type(label);
+        // Touch each counter/histogram vec so the series is created
+        m.tx_accepted_total_by_type.with_label_values(&[label]);
+        m.tx_executed_total_by_type.with_label_values(&[label]);
+        m.tx_failed_total_by_type.with_label_values(&[label]);
+        m.tx_dropped_total_by_type.with_label_values(&[label]);
+        m.tx_expired_total_by_type.with_label_values(&[label]);
+        m.node_ingress_latency_by_type.with_label_values(&[label]);
+        m.mempool_acceptance_latency_by_type.with_label_values(&[label]);
+        m.decision_response_latency_by_type.with_label_values(&[label]);
+        m.node_to_decision_response_latency_by_type.with_label_values(&[label]);
+        m.acknowledge_latency_by_type.with_label_values(&[label]);
+    }
+}
+
 pub fn inc_tx_accepted_total(value: u64) {
     CUSTOM_METRICS.tx_accepted_total.inc_by(value);
 }

--- a/metrics/src/custom_metrics.rs
+++ b/metrics/src/custom_metrics.rs
@@ -82,6 +82,7 @@ struct CustomMetrics {
     fork_rate: IntCounter,
     duplicate_confirmed_blocks: IntCounter,
 
+    mempool_size: Gauge,
     avg_locked_accounts_per_tx: Gauge,
     locked_accounts_total: AtomicU64,
     locked_accounts_samples: AtomicU64,
@@ -198,6 +199,13 @@ impl CustomMetrics {
             make_counter("duplicate_confirmed_blocks", "Duplicate confirmed block events");
         registry
             .register(Box::new(duplicate_confirmed_blocks.clone()))
+            .expect("metric registration must succeed");
+
+        let mempool_size =
+            Gauge::with_opts(Opts::new("mempool_size", "Current number of transactions in the retry pool"))
+                .expect("gauge opts must be valid");
+        registry
+            .register(Box::new(mempool_size.clone()))
             .expect("metric registration must succeed");
 
         let avg_locked_accounts_per_tx =
@@ -358,6 +366,7 @@ impl CustomMetrics {
             retry_due_to_account_in_use_rate,
             fork_rate,
             duplicate_confirmed_blocks,
+            mempool_size,
             avg_locked_accounts_per_tx,
             locked_accounts_total: AtomicU64::new(0),
             locked_accounts_samples: AtomicU64::new(0),
@@ -521,6 +530,10 @@ pub fn inc_fork_rate(value: u64) {
 
 pub fn inc_duplicate_confirmed_blocks(value: u64) {
     CUSTOM_METRICS.duplicate_confirmed_blocks.inc_by(value);
+}
+
+pub fn set_mempool_size(size: u64) {
+    CUSTOM_METRICS.mempool_size.set(size as f64);
 }
 
 pub fn observe_avg_locked_accounts_per_tx(locked_accounts: u64) {

--- a/rpc/src/tx_type_rules.rs
+++ b/rpc/src/tx_type_rules.rs
@@ -4,7 +4,7 @@ use {
     solana_sha256_hasher::hash,
     solana_transaction::sanitized::SanitizedTransaction,
     std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         sync::{LazyLock, RwLock},
     },
 };
@@ -22,6 +22,9 @@ static TX_TYPE_RULES: LazyLock<RwLock<TxTypeRuleMap>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub fn set_rules(rules: Vec<RpcTxTypeRule>) {
+    // Collect unique tx_type names before consuming rules
+    let type_names: HashSet<String> = rules.iter().map(|r| r.tx_type.clone()).collect();
+
     let map = rules
         .into_iter()
         .map(|rule| ((rule.program_id, rule.discriminator), rule.tx_type))
@@ -29,6 +32,12 @@ pub fn set_rules(rules: Vec<RpcTxTypeRule>) {
     if let Ok(mut guard) = TX_TYPE_RULES.write() {
         *guard = map;
     }
+
+    // Pre-initialize all Prometheus label series so they appear with 0
+    // even before any matching transaction arrives.
+    let mut labels: Vec<&str> = type_names.iter().map(|s| s.as_str()).collect();
+    labels.push("unknown");
+    solana_metrics::custom_metrics::init_tx_type_series(&labels);
 }
 
 pub fn infer_from_message(message: &SanitizedMessage, is_simple_vote: bool) -> String {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -371,9 +371,11 @@ impl SendTransactionService {
                                 "other",
                             );
                         }
+                        let pool_size = retry_transactions.len() as u64;
                         stats
                             .retry_queue_size
-                            .store(retry_transactions.len() as u64, Ordering::Relaxed);
+                            .store(pool_size, Ordering::Relaxed);
+                        solana_metrics::custom_metrics::set_mempool_size(pool_size);
                     }
                     last_batch_sent = Instant::now();
                 }
@@ -407,9 +409,11 @@ impl SendTransactionService {
                     retry_interval_ms = retry_interval_ms_default;
                 } else {
                     let stats = &stats_report.stats;
+                    let pool_size = transactions.len() as u64;
                     stats
                         .retry_queue_size
-                        .store(transactions.len() as u64, Ordering::Relaxed);
+                        .store(pool_size, Ordering::Relaxed);
+                    solana_metrics::custom_metrics::set_mempool_size(pool_size);
                     let (root_bank, working_bank) = {
                         let bank_forks = bank_forks.read().unwrap();
                         (root_bank.load(), bank_forks.working_bank())


### PR DESCRIPTION
Add mempool_size gauge to custom metrics, updated from both receive_txn_thread and retry_thread on each cycle.