### PR TITLE
metrics: expose scheduler buffer size / capacity as Prometheus gauges

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -72,6 +72,9 @@ where
         scheduler: S,
         worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
     ) -> Self {
+        solana_metrics::custom_metrics::set_scheduler_buffer_capacity(
+            TOTAL_BUFFERED_PACKETS as u64,
+        );
         Self {
             exit,
             decision_maker,
@@ -129,6 +132,13 @@ where
                 .iter()
                 .for_each(|metrics| metrics.maybe_report_and_reset());
             self.scheduling_details.maybe_report();
+
+            solana_metrics::custom_metrics::set_scheduler_buffer_size(
+                self.container.buffer_size() as u64,
+            );
+            solana_metrics::custom_metrics::set_scheduler_buffer_queue_size(
+                self.container.queue_size() as u64,
+            );
         }
 
         Ok(())

--- a/metrics/src/custom_metrics.rs
+++ b/metrics/src/custom_metrics.rs
@@ -83,6 +83,9 @@ struct CustomMetrics {
     duplicate_confirmed_blocks: IntCounter,
 
     mempool_size: Gauge,
+    scheduler_buffer_size: Gauge,
+    scheduler_buffer_queue_size: Gauge,
+    scheduler_buffer_capacity: Gauge,
     avg_locked_accounts_per_tx: Gauge,
     locked_accounts_total: AtomicU64,
     locked_accounts_samples: AtomicU64,
@@ -209,6 +212,33 @@ impl CustomMetrics {
                 .expect("gauge opts must be valid");
         registry
             .register(Box::new(mempool_size.clone()))
+            .expect("metric registration must succeed");
+
+        let scheduler_buffer_size = Gauge::with_opts(Opts::new(
+            "scheduler_buffer_size",
+            "Transactions held in the banking-stage scheduler container (queue + pending)",
+        ))
+        .expect("gauge opts must be valid");
+        registry
+            .register(Box::new(scheduler_buffer_size.clone()))
+            .expect("metric registration must succeed");
+
+        let scheduler_buffer_queue_size = Gauge::with_opts(Opts::new(
+            "scheduler_buffer_queue_size",
+            "Transactions currently in the scheduler priority queue (ready-to-schedule subset)",
+        ))
+        .expect("gauge opts must be valid");
+        registry
+            .register(Box::new(scheduler_buffer_queue_size.clone()))
+            .expect("metric registration must succeed");
+
+        let scheduler_buffer_capacity = Gauge::with_opts(Opts::new(
+            "scheduler_buffer_capacity",
+            "Maximum number of transactions the scheduler container can hold (TOTAL_BUFFERED_PACKETS)",
+        ))
+        .expect("gauge opts must be valid");
+        registry
+            .register(Box::new(scheduler_buffer_capacity.clone()))
             .expect("metric registration must succeed");
 
         let avg_locked_accounts_per_tx =
@@ -370,6 +400,9 @@ impl CustomMetrics {
             fork_rate,
             duplicate_confirmed_blocks,
             mempool_size,
+            scheduler_buffer_size,
+            scheduler_buffer_queue_size,
+            scheduler_buffer_capacity,
             avg_locked_accounts_per_tx,
             locked_accounts_total: AtomicU64::new(0),
             locked_accounts_samples: AtomicU64::new(0),
@@ -574,6 +607,18 @@ pub fn inc_duplicate_confirmed_blocks(value: u64) {
 
 pub fn set_mempool_size(size: u64) {
     CUSTOM_METRICS.mempool_size.set(size as f64);
+}
+
+pub fn set_scheduler_buffer_size(size: u64) {
+    CUSTOM_METRICS.scheduler_buffer_size.set(size as f64);
+}
+
+pub fn set_scheduler_buffer_queue_size(size: u64) {
+    CUSTOM_METRICS.scheduler_buffer_queue_size.set(size as f64);
+}
+
+pub fn set_scheduler_buffer_capacity(capacity: u64) {
+    CUSTOM_METRICS.scheduler_buffer_capacity.set(capacity as f64);
 }
 
 pub fn observe_avg_locked_accounts_per_tx(locked_accounts: u64) {


### PR DESCRIPTION
Adds scheduler_buffer_size, scheduler_buffer_queue_size and scheduler_buffer_capacity gauges so that fill level of the TransactionStateContainer (bumped to 1M in the previous commit) can be observed alongside tx_dropped_total{reason="capacity"}.

Capacity is set once from TOTAL_BUFFERED_PACKETS on SchedulerController construction; size and queue size are refreshed at the end of every run() iteration via cheap atomic Gauge::set on O(1) Slab/MinMaxHeap length.
