### PR TITLE
PRS-290 Details the metrics sent to the metrics database

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1173,7 +1173,8 @@ impl ConsumeWorkerMetrics {
             record_us,
             commit_us,
             find_and_send_votes_us,
-            ..
+            record_transactions_timings,
+            execute_timings,
         }: &LeaderExecuteAndCommitTimings,
     ) {
         self.timing_metrics
@@ -1200,6 +1201,131 @@ impl ConsumeWorkerMetrics {
         self.timing_metrics
             .num_batches_processed
             .fetch_add(1, Ordering::Relaxed);
+
+        use solana_svm_timings::ExecuteTimingType;
+        use std::ops::Index;
+        self.timing_metrics
+            .load_check_us
+            .fetch_add(
+                execute_timings.metrics.index(ExecuteTimingType::CheckUs).0, 
+                Ordering::Relaxed,
+            );
+
+        self.timing_metrics.load_program_cache_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::ProgramCacheUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.load_program_cache_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::ProgramCacheUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.load_validate_fees_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::ValidateFeesUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.load_accounts_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::LoadUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.load_collect_balances_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::CollectBalancesUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::ExecuteUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_filter_executable_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::FilterExecutableUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_process_message_us.fetch_add(
+            execute_timings.execute_accessories.process_message_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_process_instructions_us.fetch_add(
+            execute_timings.execute_accessories.process_instructions.total_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_process_chain_us.fetch_add(
+            execute_timings.execute_accessories.process_instructions.process_executable_chain_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_vm_create_executor_us.fetch_add(
+            execute_timings.details.get_or_create_executor_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_vm_serialize_us.fetch_add(
+            execute_timings.details.serialize_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_vm_create_us.fetch_add(
+            execute_timings.details.create_vm_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_vm_execute_us.fetch_add(
+            execute_timings.details.execute_us.0,
+            Ordering::Relaxed,
+        );
+
+         self.timing_metrics.execute_vm_deserialize_us.fetch_add(
+            execute_timings.details.deserialize_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.execute_collect_logs_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::CollectLogsUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.record_results_us.fetch_add(
+            record_transactions_timings.processing_results_to_transactions_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.record_hash_us.fetch_add(
+            record_transactions_timings.hash_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.record_poh_us.fetch_add(
+            record_transactions_timings.poh_record_us.0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.commit_store_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::StoreUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.commit_update_stake_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::UpdateStakesCacheUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.commit_update_executors_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::UpdateExecutorsUs).0,
+            Ordering::Relaxed,
+        );
+
+        self.timing_metrics.commit_update_statuses_us.fetch_add(
+            execute_timings.metrics.index(ExecuteTimingType::UpdateTransactionStatuses).0,
+            Ordering::Relaxed,
+        );
+        
     }
 
     fn update_on_error_counters(
@@ -1409,6 +1535,33 @@ struct ConsumeWorkerTimingMetrics {
     commit_us: AtomicU64,
     find_and_send_votes_us: AtomicU64,
     num_batches_processed: AtomicU64,
+
+    load_check_us: AtomicU64,
+    load_program_cache_us: AtomicU64,
+    load_validate_fees_us: AtomicU64,
+    load_accounts_us: AtomicU64,
+    load_collect_balances_us: AtomicU64,
+
+    execute_us: AtomicU64,
+    execute_filter_executable_us: AtomicU64,
+    execute_process_message_us: AtomicU64,
+    execute_process_instructions_us: AtomicU64,
+    execute_process_chain_us: AtomicU64,
+    execute_vm_create_executor_us: AtomicU64,
+    execute_vm_serialize_us: AtomicU64,
+    execute_vm_create_us: AtomicU64,
+    execute_vm_execute_us: AtomicU64,
+    execute_vm_deserialize_us: AtomicU64,
+    execute_collect_logs_us: AtomicU64,
+
+    record_results_us: AtomicU64,
+    record_hash_us: AtomicU64,
+    record_poh_us: AtomicU64,
+
+    commit_store_us: AtomicU64,
+    commit_update_stake_us: AtomicU64,
+    commit_update_executors_us: AtomicU64,
+    commit_update_statuses_us: AtomicU64,
 }
 
 impl ConsumeWorkerTimingMetrics {
@@ -1453,6 +1606,33 @@ impl ConsumeWorkerTimingMetrics {
                 self.find_and_send_votes_us.swap(0, Ordering::Relaxed),
                 i64
             ),
+
+            ("load_check_us", self.load_check_us.swap(0, Ordering::Relaxed), i64),
+            ("load_program_cache_us", self.load_program_cache_us.swap(0, Ordering::Relaxed), i64),
+            ("load_validate_fees_us", self.load_validate_fees_us.swap(0, Ordering::Relaxed), i64),
+            ("load_accounts_us", self.load_accounts_us.swap(0, Ordering::Relaxed), i64),
+            ("load_collect_balances_us", self.load_collect_balances_us.swap(0, Ordering::Relaxed), i64),
+
+            ("execute_us", self.execute_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_filter_executable_us", self.execute_filter_executable_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_process_message_us", self.execute_process_message_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_process_instructions_us", self.execute_process_instructions_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_process_chain_us", self.execute_process_chain_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_vm_create_executor_us", self.execute_vm_create_executor_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_vm_serialize_us", self.execute_vm_serialize_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_vm_create_us", self.execute_vm_create_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_vm_execute_us", self.execute_vm_execute_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_vm_deserialize_us", self.execute_vm_deserialize_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_collect_logs_us", self.execute_collect_logs_us.swap(0, Ordering::Relaxed), i64),
+
+            ("record_results_us", self.record_results_us.swap(0, Ordering::Relaxed), i64),
+            ("record_hash_us", self.record_hash_us.swap(0, Ordering::Relaxed), i64),
+            ("record_poh_us", self.record_poh_us.swap(0, Ordering::Relaxed), i64),
+
+            ("commit_store_us", self.commit_store_us.swap(0, Ordering::Relaxed), i64),
+            ("commit_update_stake_us", self.commit_update_stake_us.swap(0, Ordering::Relaxed), i64),
+            ("commit_update_executor_us", self.commit_update_executors_us.swap(0, Ordering::Relaxed), i64),
+            ("commit_update_statuses_us", self.commit_update_statuses_us.swap(0, Ordering::Relaxed), i64),
         );
     }
 }

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1286,6 +1286,11 @@ impl ConsumeWorkerMetrics {
             Ordering::Relaxed,
         );
 
+        self.timing_metrics.execute_load_subaccounts_us.fetch_add(
+            execute_timings.details.load_subaccounts_us.0,
+            Ordering::Relaxed,
+        );
+
         self.timing_metrics.execute_collect_logs_us.fetch_add(
             execute_timings.metrics.index(ExecuteTimingType::CollectLogsUs).0,
             Ordering::Relaxed,
@@ -1552,6 +1557,7 @@ struct ConsumeWorkerTimingMetrics {
     execute_vm_create_us: AtomicU64,
     execute_vm_execute_us: AtomicU64,
     execute_vm_deserialize_us: AtomicU64,
+    execute_load_subaccounts_us: AtomicU64,
     execute_collect_logs_us: AtomicU64,
 
     record_results_us: AtomicU64,
@@ -1623,6 +1629,7 @@ impl ConsumeWorkerTimingMetrics {
             ("execute_vm_create_us", self.execute_vm_create_us.swap(0, Ordering::Relaxed), i64),
             ("execute_vm_execute_us", self.execute_vm_execute_us.swap(0, Ordering::Relaxed), i64),
             ("execute_vm_deserialize_us", self.execute_vm_deserialize_us.swap(0, Ordering::Relaxed), i64),
+            ("execute_load_subaccounts_us", self.execute_load_subaccounts_us.swap(0, Ordering::Relaxed), i64),
             ("execute_collect_logs_us", self.execute_collect_logs_us.swap(0, Ordering::Relaxed), i64),
 
             ("record_results_us", self.record_results_us.swap(0, Ordering::Relaxed), i64),

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -34,11 +34,7 @@ impl LeaderExecuteAndCommitTimings {
             ("freeze_lock_us", self.freeze_lock_us as i64, i64),
             ("record_us", self.record_us as i64, i64),
             ("commit_us", self.commit_us as i64, i64),
-            (
-                "find_and_send_votes_us",
-                self.find_and_send_votes_us as i64,
-                i64
-            ),
+            ("find_and_send_votes_us", self.find_and_send_votes_us as i64, i64),
         );
 
         datapoint_info!(

--- a/svm-timings/src/lib.rs
+++ b/svm-timings/src/lib.rs
@@ -393,6 +393,7 @@ pub struct ExecuteDetailsTimings {
     pub create_vm_us: Saturating<u64>,
     pub execute_us: Saturating<u64>,
     pub deserialize_us: Saturating<u64>,
+    pub load_subaccounts_us: Saturating<u64>,
     pub get_or_create_executor_us: Saturating<u64>,
     pub changed_account_count: Saturating<u64>,
     pub total_account_count: Saturating<u64>,
@@ -409,6 +410,7 @@ impl ExecuteDetailsTimings {
         self.create_vm_us += other.create_vm_us;
         self.execute_us += other.execute_us;
         self.deserialize_us += other.deserialize_us;
+        self.load_subaccounts_us += other.load_subaccounts_us;
         self.get_or_create_executor_us += other.get_or_create_executor_us;
         self.changed_account_count += other.changed_account_count;
         self.total_account_count += other.total_account_count;

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -20,6 +20,7 @@ pub use self::{
     },
 };
 use solana_program_runtime::memory::translate_vm_slice;
+use solana_svm_measure::measure::Measure;
 #[allow(deprecated)]
 use {
     crate::mem_ops::is_nonoverlapping,
@@ -2768,6 +2769,7 @@ fn build_next_instruction_subaccounts(
     invoke_context: &mut InvokeContext,
     subaccounts_seeds: &[(Pubkey, bool)],
 ) -> Result<Vec<InstructionAccount>, Error> {
+    let mut load_subaccounts_time = Measure::start("load_subaccounts");
     let mut next_instruction_subaccounts = Vec::with_capacity(subaccounts_seeds.len());
     for (subaccount_pubkey, is_writable) in subaccounts_seeds {
         let subaccount_index = if let Some(subaccount_index) = invoke_context
@@ -2794,6 +2796,8 @@ fn build_next_instruction_subaccounts(
             *is_writable,
         ));
     }
+    load_subaccounts_time.stop();
+    invoke_context.timings.load_subaccounts_us += load_subaccounts_time.as_us();
     Ok(next_instruction_subaccounts)
 }
 


### PR DESCRIPTION
The consumer worker collects a wealth of information about how long a particular piece of code takes. However, this information is mostly printed in logs and isn't accessible through the metrics database. This PR adds detail to the basic metrics `load_execute_us`, `freeze_lock_us`, `record_us`, `commit_us`, and `find_and_send_votes_us`.
Below is a complete picture of how these metrics are nested (on the left are the fields in the `LeaderExecuteAndCommitTimings` structure, on the right is the metric name under which it is exported to `banking_stage_worker_timing`):
- **load_execute_us**:
	- metrics\[CheckUs] -> **load_check_us**
	- metrics\[ProgramCacheUs] -> **load_program_cache_us**
	- metrics\[ValidateFeesUs] -> **load_validate_fees_us**
	- metrics\[LoadUs] -> **load_accounts_us**
	- metrics\[CollectBalancesUs] -> **load_collect_balances_us**
	- metrics\[ExecuteUs]: -> **execute_us**
		- metrics\[FilterExecutableUs] -> **execute_filter_executable_us**
		- metrics\[ProgramCacheUs] // DUPLICATE
		- execute_accessories.process_message_us:  -> **execute_process_message_us**
			- execute_accessories.process_instructions.total_us: -> **execute_process_instructions_us**
				- execute_accessories.process_instruction.process_executable_chain_us: -> **execute_process_chain_us**
				  Next items processed inside SVM (all located in `execute_timings.details`)
					- got_or_create_executor_us -> **execute_vm_create_executor_us**
					- serialize_us -> **execute_vm_serialize_us**
					- create_vm_us -> **execute_vm_create_us**
					- execute_us -> **execute_vm_execute_us**
					- deserialize_us -> **execute_vm_deserialize_us**
					- load_subaccounts_us -> **execute_load_subaccounts_us**
	- metrics\[CollectLogs] -> **execute_collect_logs_us**
- **freeze_lock_us**
- **record_us**
	- record_transactions_timings.processing_results_to_trxs_us -> **record_results_us**
	- record_transactions_timings.hash_us -> **record_hash_us**
	- record_transactions_timings.poh_record_us -> **record_poh_us**
- **commit_us**:
	- metrics\[StoreUs] -> **commit_store_us**
	- metrics\[UpdateStakesCacheUs] -> **commit_update_stake_us**
	- metrics\[UpdateExecutorUs] -> **commit_update_executor_us**
	- metrics\[UpdateTransactionStatuses] -> **commit_update_statuses_us**
- **find_and_send_votes_us**