### PR TITLE
feat(F1-100ms): track SDK parasol-100ms (block time 100 ms)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "neon/solana-sdk"]
 	path = neon/solana-sdk
 	url = https://github.com/neonlabsorg/solana-sdk
-	branch = parasol-dev
+	branch = parasol-100ms


### PR DESCRIPTION
Bumps neon/solana-sdk submodule to parasol-100ms HEAD 99cfff97 and points .gitmodules tracking branch accordingly. SDK side raises DEFAULT_TICKS_PER_SLOT 4->16 and the dependent constants; agave consumes them via existing [patch.crates-io] wiring. cargo check --workspace and cargo build -p agave-validator -p solana-cli green.
