### PR TITLE
PRS-155 Add the list of loaded subaccounts to the transaction receipt

### DIFF
--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -196,6 +196,39 @@ impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(&'a Pubkey, &'a AccountSh
     }
 }
 
+// F10/PRS-314: owned `Pubkey` + borrowed `AccountSharedData` so callers like
+// `account_saver::collect_accounts_to_store` can emit derived addresses
+// (e.g. `subaccount_storage_address(owner)`) without backing storage for the
+// derived key.
+impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, &'a AccountSharedData)]) {
+    fn account<Ret>(
+        &self,
+        index: usize,
+        mut callback: impl for<'local> FnMut(AccountForStorage<'local>) -> Ret,
+    ) -> Ret {
+        callback((&self.1[index].0, self.1[index].1).into())
+    }
+    fn is_zero_lamport(&self, index: usize) -> bool {
+        self.1[index].1.is_zero_lamport()
+    }
+    fn data_len(&self, index: usize) -> usize {
+        self.1[index].1.data().len()
+    }
+    fn pubkey(&self, index: usize) -> &Pubkey {
+        &self.1[index].0
+    }
+    fn slot(&self, _index: usize) -> Slot {
+        // per-index slot is not unique per slot when per-account slot is not included in the source data
+        self.target_slot()
+    }
+    fn target_slot(&self) -> Slot {
+        self.0
+    }
+    fn len(&self) -> usize {
+        self.1.len()
+    }
+}
+
 impl<'a: 'b, 'b> StorableAccounts<'a> for (Slot, &'b [(Pubkey, AccountSharedData)]) {
     fn account<Ret>(
         &self,

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -823,6 +823,7 @@ mod test {
             compute_units_consumed: Some(1234u64),
             cost_units: Some(5678),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         };
 
         let output = {
@@ -904,6 +905,7 @@ Rewards:
             compute_units_consumed: Some(2345u64),
             cost_units: Some(5678),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         };
 
         let output = {

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -822,6 +822,7 @@ mod test {
             }),
             compute_units_consumed: Some(1234u64),
             cost_units: Some(5678),
+            subaccount_addresses: vec![],
         };
 
         let output = {
@@ -902,6 +903,7 @@ Rewards:
             }),
             compute_units_consumed: Some(2345u64),
             cost_units: Some(5678),
+            subaccount_addresses: vec![],
         };
 
         let output = {

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -173,7 +173,7 @@ impl Committer {
             // Therefore this should always be true.
             debug_assert!(balance_collector.is_some());
 
-            let (balances, token_balances) =
+            let (balances, token_balances, subaccount_keys) =
                 compile_collected_balances(balance_collector.unwrap_or_default());
 
             transaction_status_sender.send_transaction_status_batch(
@@ -184,6 +184,7 @@ impl Committer {
                 token_balances,
                 tx_costs,
                 batch_transaction_indexes,
+                subaccount_keys,
             );
         }
     }

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -173,7 +173,7 @@ impl Committer {
             // Therefore this should always be true.
             debug_assert!(balance_collector.is_some());
 
-            let (balances, token_balances, subaccount_keys) =
+            let (balances, token_balances, subaccount_keys, unchanged_subaccount_keys) =
                 compile_collected_balances(balance_collector.unwrap_or_default());
 
             transaction_status_sender.send_transaction_status_batch(
@@ -185,6 +185,7 @@ impl Committer {
                 tx_costs,
                 batch_transaction_indexes,
                 subaccount_keys,
+                unchanged_subaccount_keys,
             );
         }
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8086,6 +8086,7 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8106,6 +8107,7 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8126,6 +8128,7 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8148,6 +8151,7 @@ pub mod tests {
                         return_data: Some(TransactionReturnData::default()),
                         compute_units_consumed,
                         cost_units,
+                        subaccount_addresses: vec![],
                     },
                 }
             })
@@ -8298,6 +8302,7 @@ pub mod tests {
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_1,
             cost_units: cost_units_1,
+            subaccount_addresses: vec![],
         }
         .into();
         assert!(transaction_status_cf
@@ -8319,6 +8324,7 @@ pub mod tests {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses: _,
         } = transaction_status_cf
             .get_protobuf((Signature::default(), 0))
             .unwrap()
@@ -8354,6 +8360,7 @@ pub mod tests {
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_2,
             cost_units: cost_units_2,
+            subaccount_addresses: vec![],
         }
         .into();
         assert!(transaction_status_cf
@@ -8375,6 +8382,7 @@ pub mod tests {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses: _,
         } = transaction_status_cf
             .get_protobuf((Signature::from([2u8; 64]), 9))
             .unwrap()
@@ -8493,6 +8501,7 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            subaccount_addresses: vec![],
         }
         .into();
 
@@ -8670,6 +8679,7 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            subaccount_addresses: vec![],
         }
         .into();
 
@@ -8798,6 +8808,7 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            subaccount_addresses: vec![],
         }
         .into();
 
@@ -8967,6 +8978,7 @@ pub mod tests {
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42),
                     cost_units: Some(1234),
+                    subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8989,6 +9001,7 @@ pub mod tests {
                         return_data,
                         compute_units_consumed: Some(42),
                         cost_units: Some(1234),
+                        subaccount_addresses: vec![],
                     },
                 }
             })
@@ -9090,6 +9103,7 @@ pub mod tests {
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42u64),
                     cost_units: Some(1234),
+                    subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -9112,6 +9126,7 @@ pub mod tests {
                         return_data,
                         compute_units_consumed: Some(42u64),
                         cost_units: Some(1234),
+                        subaccount_addresses: vec![],
                     },
                 }
             })
@@ -9787,6 +9802,7 @@ pub mod tests {
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: None,
                 cost_units: None,
+                subaccount_addresses: vec![],
             }
             .into();
             transaction_status_cf
@@ -10590,6 +10606,7 @@ pub mod tests {
             }),
             compute_units_consumed: Some(23456),
             cost_units: Some(5678),
+            subaccount_addresses: vec![],
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8087,6 +8087,7 @@ pub mod tests {
                     compute_units_consumed,
                     cost_units,
                     subaccount_addresses: vec![],
+                    unchanged_subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8108,6 +8109,7 @@ pub mod tests {
                     compute_units_consumed,
                     cost_units,
                     subaccount_addresses: vec![],
+                    unchanged_subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8129,6 +8131,7 @@ pub mod tests {
                     compute_units_consumed,
                     cost_units,
                     subaccount_addresses: vec![],
+                    unchanged_subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -8152,6 +8155,7 @@ pub mod tests {
                         compute_units_consumed,
                         cost_units,
                         subaccount_addresses: vec![],
+                        unchanged_subaccount_addresses: vec![],
                     },
                 }
             })
@@ -8303,6 +8307,7 @@ pub mod tests {
             compute_units_consumed: compute_units_consumed_1,
             cost_units: cost_units_1,
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
         .into();
         assert!(transaction_status_cf
@@ -8325,6 +8330,7 @@ pub mod tests {
             compute_units_consumed,
             cost_units,
             subaccount_addresses: _,
+            unchanged_subaccount_addresses: _,
         } = transaction_status_cf
             .get_protobuf((Signature::default(), 0))
             .unwrap()
@@ -8361,6 +8367,7 @@ pub mod tests {
             compute_units_consumed: compute_units_consumed_2,
             cost_units: cost_units_2,
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
         .into();
         assert!(transaction_status_cf
@@ -8383,6 +8390,7 @@ pub mod tests {
             compute_units_consumed,
             cost_units,
             subaccount_addresses: _,
+            unchanged_subaccount_addresses: _,
         } = transaction_status_cf
             .get_protobuf((Signature::from([2u8; 64]), 9))
             .unwrap()
@@ -8502,6 +8510,7 @@ pub mod tests {
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
         .into();
 
@@ -8680,6 +8689,7 @@ pub mod tests {
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
         .into();
 
@@ -8809,6 +8819,7 @@ pub mod tests {
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
         .into();
 
@@ -8979,6 +8990,7 @@ pub mod tests {
                     compute_units_consumed: Some(42),
                     cost_units: Some(1234),
                     subaccount_addresses: vec![],
+                    unchanged_subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -9002,6 +9014,7 @@ pub mod tests {
                         compute_units_consumed: Some(42),
                         cost_units: Some(1234),
                         subaccount_addresses: vec![],
+                        unchanged_subaccount_addresses: vec![],
                     },
                 }
             })
@@ -9104,6 +9117,7 @@ pub mod tests {
                     compute_units_consumed: Some(42u64),
                     cost_units: Some(1234),
                     subaccount_addresses: vec![],
+                    unchanged_subaccount_addresses: vec![],
                 }
                 .into();
                 blockstore
@@ -9127,6 +9141,7 @@ pub mod tests {
                         compute_units_consumed: Some(42u64),
                         cost_units: Some(1234),
                         subaccount_addresses: vec![],
+                        unchanged_subaccount_addresses: vec![],
                     },
                 }
             })
@@ -9803,6 +9818,7 @@ pub mod tests {
                 compute_units_consumed: None,
                 cost_units: None,
                 subaccount_addresses: vec![],
+                unchanged_subaccount_addresses: vec![],
             }
             .into();
             transaction_status_cf
@@ -10607,6 +10623,7 @@ pub mod tests {
             compute_units_consumed: Some(23456),
             cost_units: Some(5678),
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -283,7 +283,7 @@ pub fn execute_batch<'a>(
         // Therefore this should always be true.
         debug_assert!(balance_collector.is_some());
 
-        let (balances, token_balances, subaccount_keys) =
+        let (balances, token_balances, subaccount_keys, unchanged_subaccount_keys) =
             compile_collected_balances(balance_collector.unwrap_or_default());
 
         // The length of costs vector needs to be consistent with all other
@@ -303,6 +303,7 @@ pub fn execute_batch<'a>(
             tx_costs,
             transaction_indexes.into_owned(),
             subaccount_keys,
+            unchanged_subaccount_keys,
         );
     }
 
@@ -2275,6 +2276,9 @@ pub struct TransactionStatusBatch {
     // (positions [account_keys.len()..)). Empty inner Vec for txs without
     // subaccount activity.
     pub subaccount_keys: Vec<Vec<Pubkey>>,
+    // F10/PRS-155: per-tx owner-facing pubkeys of subaccounts accessed but left
+    // unchanged (read-only). Reported by address only — no associated balances.
+    pub unchanged_subaccount_keys: Vec<Vec<Pubkey>>,
 }
 
 #[derive(Clone, Debug)]
@@ -2294,6 +2298,7 @@ impl TransactionStatusSender {
         costs: Vec<Option<u64>>,
         transaction_indexes: Vec<usize>,
         subaccount_keys: Vec<Vec<Pubkey>>,
+        unchanged_subaccount_keys: Vec<Vec<Pubkey>>,
     ) {
         let work_sequence = self
             .dependency_tracker
@@ -2310,6 +2315,7 @@ impl TransactionStatusSender {
                 costs,
                 transaction_indexes,
                 subaccount_keys,
+                unchanged_subaccount_keys,
             },
             work_sequence,
         ))) {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -283,7 +283,7 @@ pub fn execute_batch<'a>(
         // Therefore this should always be true.
         debug_assert!(balance_collector.is_some());
 
-        let (balances, token_balances) =
+        let (balances, token_balances, subaccount_keys) =
             compile_collected_balances(balance_collector.unwrap_or_default());
 
         // The length of costs vector needs to be consistent with all other
@@ -302,6 +302,7 @@ pub fn execute_batch<'a>(
             token_balances,
             tx_costs,
             transaction_indexes.into_owned(),
+            subaccount_keys,
         );
     }
 
@@ -2269,6 +2270,11 @@ pub struct TransactionStatusBatch {
     pub token_balances: TransactionTokenBalancesSet,
     pub costs: Vec<Option<u64>>,
     pub transaction_indexes: Vec<usize>,
+    // F10/PRS-314: per-tx owner-facing pubkeys of subaccounts touched, aligned
+    // with the tail of `balances.pre_balances`/`balances.post_balances`
+    // (positions [account_keys.len()..)). Empty inner Vec for txs without
+    // subaccount activity.
+    pub subaccount_keys: Vec<Vec<Pubkey>>,
 }
 
 #[derive(Clone, Debug)]
@@ -2287,6 +2293,7 @@ impl TransactionStatusSender {
         token_balances: TransactionTokenBalancesSet,
         costs: Vec<Option<u64>>,
         transaction_indexes: Vec<usize>,
+        subaccount_keys: Vec<Vec<Pubkey>>,
     ) {
         let work_sequence = self
             .dependency_tracker
@@ -2302,6 +2309,7 @@ impl TransactionStatusSender {
                 token_balances,
                 costs,
                 transaction_indexes,
+                subaccount_keys,
             },
             work_sequence,
         ))) {

--- a/ledger/src/transaction_balances.rs
+++ b/ledger/src/transaction_balances.rs
@@ -16,10 +16,21 @@ pub fn compile_collected_balances(
 ) -> (
     TransactionBalancesSet,
     TransactionTokenBalancesSet,
+    // Owner-facing keys of *changed* subaccounts, aligned with the tail of the
+    // native pre/post balances.
+    Vec<Vec<Pubkey>>,
+    // F10/PRS-155: owner-facing keys of *unchanged* subaccounts (read-only),
+    // reported by address only — no pre/post balances.
     Vec<Vec<Pubkey>>,
 ) {
-    let (native_pre, native_post, token_pre, token_post, subaccount_keys) =
-        balance_collector.into_vecs();
+    let (
+        native_pre,
+        native_post,
+        token_pre,
+        token_post,
+        subaccount_keys,
+        unchanged_subaccount_keys,
+    ) = balance_collector.into_vecs();
 
     let native_balances = TransactionBalancesSet::new(native_pre, native_post);
     let token_balances = TransactionTokenBalancesSet::new(
@@ -27,7 +38,12 @@ pub fn compile_collected_balances(
         collected_token_infos_to_token_balances(token_post),
     );
 
-    (native_balances, token_balances, subaccount_keys)
+    (
+        native_balances,
+        token_balances,
+        subaccount_keys,
+        unchanged_subaccount_keys,
+    )
 }
 
 fn collected_token_infos_to_token_balances(
@@ -149,9 +165,10 @@ mod tests {
             token_pre,
             token_post,
             subaccount_keys: vec![vec![], vec![]],
+            unchanged_subaccount_keys: vec![vec![], vec![]],
         };
 
-        let (actual_native, actual_token, actual_subaccount_keys) =
+        let (actual_native, actual_token, actual_subaccount_keys, actual_unchanged_subaccount_keys) =
             compile_collected_balances(balance_collector);
 
         assert_eq!(expected_native.pre_balances, actual_native.pre_balances);
@@ -167,6 +184,10 @@ mod tests {
         );
         assert_eq!(
             actual_subaccount_keys,
+            vec![Vec::<Pubkey>::new(), Vec::<Pubkey>::new()]
+        );
+        assert_eq!(
+            actual_unchanged_subaccount_keys,
             vec![Vec::<Pubkey>::new(), Vec::<Pubkey>::new()]
         );
     }

--- a/ledger/src/transaction_balances.rs
+++ b/ledger/src/transaction_balances.rs
@@ -2,6 +2,7 @@ use {
     solana_account_decoder::{
         parse_account_data::SplTokenAdditionalDataV2, parse_token::token_amount_to_ui_amount_v3,
     },
+    solana_pubkey::Pubkey,
     solana_runtime::bank::TransactionBalancesSet,
     solana_svm::transaction_balances::{BalanceCollector, SvmTokenInfo},
     solana_transaction_status::{
@@ -9,11 +10,16 @@ use {
     },
 };
 
-// decompose the contents of BalanceCollector into the two structs required by TransactionStatusSender
+// decompose the contents of BalanceCollector into the structs required by TransactionStatusSender
 pub fn compile_collected_balances(
     balance_collector: BalanceCollector,
-) -> (TransactionBalancesSet, TransactionTokenBalancesSet) {
-    let (native_pre, native_post, token_pre, token_post) = balance_collector.into_vecs();
+) -> (
+    TransactionBalancesSet,
+    TransactionTokenBalancesSet,
+    Vec<Vec<Pubkey>>,
+) {
+    let (native_pre, native_post, token_pre, token_post, subaccount_keys) =
+        balance_collector.into_vecs();
 
     let native_balances = TransactionBalancesSet::new(native_pre, native_post);
     let token_balances = TransactionTokenBalancesSet::new(
@@ -21,7 +27,7 @@ pub fn compile_collected_balances(
         collected_token_infos_to_token_balances(token_post),
     );
 
-    (native_balances, token_balances)
+    (native_balances, token_balances, subaccount_keys)
 }
 
 fn collected_token_infos_to_token_balances(
@@ -142,9 +148,11 @@ mod tests {
             native_post,
             token_pre,
             token_post,
+            subaccount_keys: vec![vec![], vec![]],
         };
 
-        let (actual_native, actual_token) = compile_collected_balances(balance_collector);
+        let (actual_native, actual_token, actual_subaccount_keys) =
+            compile_collected_balances(balance_collector);
 
         assert_eq!(expected_native.pre_balances, actual_native.pre_balances);
         assert_eq!(expected_native.post_balances, actual_native.post_balances);
@@ -156,6 +164,10 @@ mod tests {
         assert_eq!(
             expected_token.post_token_balances,
             actual_token.post_token_balances
+        );
+        assert_eq!(
+            actual_subaccount_keys,
+            vec![Vec::<Pubkey>::new(), Vec::<Pubkey>::new()]
         );
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -6882,7 +6882,7 @@ fn test_program_sbf_subaccount_addresses_in_status_meta() {
 
     let balance_collector =
         balance_collector.expect("balance recording was enabled, collector must exist");
-    let (balances, _token_balances, subaccount_keys) =
+    let (balances, _token_balances, subaccount_keys, _unchanged_subaccount_keys) =
         compile_collected_balances(balance_collector);
 
     // Single-transaction batch ⇒ index 0.
@@ -6951,5 +6951,120 @@ fn test_program_sbf_subaccount_addresses_in_status_meta() {
             );
         }
         other => panic!("expected Ui subaccount_addresses to be Some, got {other:?}"),
+    }
+}
+
+/// PRS-155: a read-only `sol_read_subaccount` of an existing subaccount must
+/// surface that subaccount in the receipt's *unchanged* lane
+/// (`unchanged_subaccount_addresses`, owner key only) and NOT in the *changed*
+/// lane (`subaccount_addresses` + the pre/post balance tails). Complements
+/// `test_program_sbf_subaccount_addresses_in_status_meta`, which covers the
+/// changed lane.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_unchanged_addresses_in_status_meta() {
+    use {
+        solana_ledger::transaction_balances::compile_collected_balances,
+        solana_transaction_context::create_subaccount_address,
+    };
+
+    let (bank, _bank_client, _bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let base_pubkey = Pubkey::new_unique();
+    let payer_pubkey = mint_keypair.pubkey();
+    let content: &[u8] = b"read-subaccount-content-32-bytes";
+
+    // Tx1 — create + write the subaccount so it exists on-chain for Tx2 to read.
+    let ix1 =
+        subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, content, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "Tx1 create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n"),
+    );
+
+    // Tx2 — read-only `sol_read_subaccount` (do_create = false, do_load = false),
+    // with transaction balance recording enabled.
+    let payload = subaccount_read_payload(false, false, 0, content.len() as u64, content);
+    let ix2 =
+        subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 9, &payload, vec![]);
+    let tx2 = Transaction::new_signed_with_payer(
+        &[ix2],
+        Some(&payer_pubkey),
+        &[&mint_keypair],
+        bank.last_blockhash(),
+    );
+    let account_keys_len = tx2.message.account_keys.len();
+
+    let tx_batch = bank.prepare_batch_for_tests(vec![tx2]);
+    let (mut commit_results, balance_collector) = bank.load_execute_and_commit_transactions(
+        &tx_batch,
+        MAX_PROCESSING_AGE,
+        ExecutionRecordingConfig {
+            enable_cpi_recording: false,
+            enable_log_recording: true,
+            enable_return_data_recording: false,
+            enable_transaction_balance_recording: true,
+        },
+        &mut ExecuteTimings::default(),
+        None,
+    );
+
+    let committed = commit_results.pop().unwrap().expect("read tx must commit");
+    assert!(
+        committed.status.is_ok(),
+        "Tx2 read failed: {:?}\nlogs:\n{}",
+        committed.status,
+        committed.log_messages.clone().unwrap_or_default().join("\n"),
+    );
+
+    let balance_collector =
+        balance_collector.expect("balance recording was enabled, collector must exist");
+    let (balances, _token_balances, subaccount_keys, unchanged_subaccount_keys) =
+        compile_collected_balances(balance_collector);
+
+    let expected_owner =
+        create_subaccount_address(&[base_pubkey.as_ref(), SUBACCOUNT_SEED_TAG], &program_id)
+            .expect("derive owner-facing subaccount pubkey");
+
+    // The read-only subaccount belongs to the unchanged lane, by owner key only.
+    assert!(
+        subaccount_keys[0].is_empty(),
+        "a read-only tx must not record any changed subaccount, got {:?}",
+        subaccount_keys[0],
+    );
+    assert_eq!(
+        &unchanged_subaccount_keys[0],
+        &vec![expected_owner],
+        "the read-only subaccount must be reported in the unchanged lane by owner key",
+    );
+
+    // Unchanged subaccounts carry no balance tail — pre/post stay sized to the
+    // transaction's account keys only.
+    assert_eq!(
+        balances.pre_balances[0].len(),
+        account_keys_len,
+        "unchanged subaccounts must not extend the pre_balances tail",
+    );
+    assert_eq!(
+        balances.post_balances[0].len(),
+        account_keys_len,
+        "unchanged subaccounts must not extend the post_balances tail",
+    );
+
+    // And it survives into the receipt meta's unchanged lane.
+    let meta = solana_transaction_status::TransactionStatusMeta {
+        status: committed.status.clone(),
+        unchanged_subaccount_addresses: unchanged_subaccount_keys[0].clone(),
+        ..solana_transaction_status::TransactionStatusMeta::default()
+    };
+    let ui_meta: solana_transaction_status::UiTransactionStatusMeta = meta.into();
+    match ui_meta.unchanged_subaccount_addresses {
+        solana_transaction_status::option_serializer::OptionSerializer::Some(ref addrs) => {
+            assert_eq!(addrs, &vec![expected_owner.to_string()]);
+        }
+        other => panic!("expected Ui unchanged_subaccount_addresses Some, got {other:?}"),
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -7017,7 +7017,11 @@ fn test_program_sbf_subaccount_unchanged_addresses_in_status_meta() {
         committed.status.is_ok(),
         "Tx2 read failed: {:?}\nlogs:\n{}",
         committed.status,
-        committed.log_messages.clone().unwrap_or_default().join("\n"),
+        committed
+            .log_messages
+            .clone()
+            .unwrap_or_default()
+            .join("\n"),
     );
 
     let balance_collector =
@@ -7067,4 +7071,283 @@ fn test_program_sbf_subaccount_unchanged_addresses_in_status_meta() {
         }
         other => panic!("expected Ui unchanged_subaccount_addresses Some, got {other:?}"),
     }
+}
+
+/// PRS-155 regression: the subaccount **pre**-balance recorded for an *existing*
+/// on-chain subaccount that is loaded for the first time in THIS transaction
+/// must be its real pre-tx balance — NOT a cache-miss `0`.
+///
+/// `collect_subaccount_pre_balances` reads pre-state via
+/// `account_loader.load_account(&subaccount_storage_address(owner))` and falls
+/// back to `0` on a `None`. For a freshly-created subaccount `0` is correct,
+/// but for an already-funded subaccount loaded fresh this tx, `load_account`
+/// must fall through to accounts-db and return the funded balance. This test
+/// funds a subaccount in Tx1, then in a later slot loads + mutates it (so it
+/// lands in the *changed* lane, which carries pre/post balances) and asserts
+/// the pre-balance tail equals the funded amount.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_pre_balance_real_for_existing_loaded_fresh() {
+    use {
+        solana_ledger::transaction_balances::compile_collected_balances,
+        solana_transaction_context::create_subaccount_address,
+    };
+
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let base_pubkey = Pubkey::new_unique();
+    let payer_pubkey = mint_keypair.pubkey();
+    let content_v1: &[u8] = b"read-subaccount-content-32-bytes"; // 32 bytes
+    let content_v2: &[u8] = b"OVERWRITTEN-subaccount-32-bytes!"; // 32 bytes, same len
+    assert_eq!(content_v1.len(), content_v2.len());
+
+    // Tx1 — create + fund the subaccount so it lives on-chain at its storage
+    // address with `SUBACCOUNT_FUNDING_LAMPORTS`.
+    let ix1 =
+        subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, content_v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "Tx1 create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n"),
+    );
+    let storage_addr = subaccount_storage_addr_for(&base_pubkey, &program_id);
+    assert_eq!(
+        bank.get_account(&storage_addr)
+            .expect("subaccount must exist after create")
+            .lamports(),
+        SUBACCOUNT_FUNDING_LAMPORTS,
+    );
+
+    // Advance into a new slot so Tx2 loads the subaccount fresh (the loader
+    // cache for this batch starts empty for its storage address).
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for Tx2");
+
+    // Tx2 — load the existing subaccount + overwrite its data (same length, so
+    // lamports stay put), with balance recording on. disc=1. The writable load
+    // marks it touched, so it lands in the changed lane.
+    let ix2 = subaccount_instruction(program_id, base_pubkey, true, 1, content_v2, vec![]);
+    let tx2 = Transaction::new_signed_with_payer(
+        &[ix2],
+        Some(&payer_pubkey),
+        &[&mint_keypair],
+        bank.last_blockhash(),
+    );
+    let account_keys_len = tx2.message.account_keys.len();
+
+    let tx_batch = bank.prepare_batch_for_tests(vec![tx2]);
+    let (mut commit_results, balance_collector) = bank.load_execute_and_commit_transactions(
+        &tx_batch,
+        MAX_PROCESSING_AGE,
+        ExecutionRecordingConfig {
+            enable_cpi_recording: false,
+            enable_log_recording: true,
+            enable_return_data_recording: false,
+            enable_transaction_balance_recording: true,
+        },
+        &mut ExecuteTimings::default(),
+        None,
+    );
+
+    let committed = commit_results.pop().unwrap().expect("Tx2 must commit");
+    assert!(
+        committed.status.is_ok(),
+        "Tx2 failed: {:?}\nlogs:\n{}",
+        committed.status,
+        committed
+            .log_messages
+            .clone()
+            .unwrap_or_default()
+            .join("\n"),
+    );
+
+    let balance_collector =
+        balance_collector.expect("balance recording was enabled, collector must exist");
+    let (balances, _token_balances, subaccount_keys, _unchanged_subaccount_keys) =
+        compile_collected_balances(balance_collector);
+
+    let expected_owner =
+        create_subaccount_address(&[base_pubkey.as_ref(), SUBACCOUNT_SEED_TAG], &program_id)
+            .expect("derive owner-facing subaccount pubkey");
+
+    // The mutated existing subaccount is in the changed lane (carries balances).
+    assert_eq!(
+        &subaccount_keys[0],
+        &vec![expected_owner],
+        "a loaded + mutated existing subaccount must be in the changed lane",
+    );
+
+    let pre = &balances.pre_balances[0];
+    let post = &balances.post_balances[0];
+    assert_eq!(
+        pre.len(),
+        account_keys_len + 1,
+        "one subaccount pre tail entry"
+    );
+    assert_eq!(post.len(), account_keys_len + 1);
+
+    // The crux: the pre-balance is the REAL pre-tx funded amount, proving
+    // `load_account` fell through to accounts-db rather than returning a
+    // cache-miss 0 for an existing subaccount loaded fresh this tx.
+    assert_eq!(
+        pre[account_keys_len], SUBACCOUNT_FUNDING_LAMPORTS,
+        "pre-balance of an existing subaccount loaded fresh must be its real \
+         pre-tx balance, not a cache-miss 0",
+    );
+    // Only data changed this tx; lamports are unchanged.
+    assert_eq!(post[account_keys_len], SUBACCOUNT_FUNDING_LAMPORTS);
+}
+
+/// PRS-155 B9 end-to-end: a single transaction that **creates** one subaccount
+/// (ix 0, base A) and **loads + mutates an existing** one (ix 1, base B, funded
+/// in a prior slot). Both land in the changed lane, so the receipt must:
+///   - expose exactly two `subaccount_addresses`;
+///   - keep them in lane order (A created first, then B), aligned one-for-one
+///     with the `pre_balances`/`post_balances` tails at `[head + i]`.
+///
+/// The created subaccount A has pre-balance 0 (didn't exist) and post-balance
+/// = funding; the existing subaccount B has pre = post = its prior funding.
+/// That asymmetry pins the address↔balance correspondence by index.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_create_and_load_existing_addresses_ordered() {
+    use {
+        solana_ledger::transaction_balances::compile_collected_balances,
+        solana_transaction_context::create_subaccount_address,
+        solana_transaction_status::TransactionStatusMeta,
+    };
+
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_a = Pubkey::new_unique(); // created in the main tx
+    let base_b = Pubkey::new_unique(); // funded now, loaded in the main tx
+    let content_a: &[u8] = b"create-subaccount-A--32-bytes!!!"; // 32 bytes
+    let content_b_v1: &[u8] = b"existing-subaccount-B-32-bytes!!"; // 32 bytes
+    let content_b_v2: &[u8] = b"B-overwritten-in-main-tx-32bytes"; // 32 bytes
+    assert_eq!(content_a.len(), 32);
+    assert_eq!(content_b_v1.len(), content_b_v2.len());
+
+    // Tx0 — bring subaccount B on-chain (create + fund) in an earlier slot.
+    let ix_b0 =
+        subaccount_create_instruction(program_id, base_b, payer_pubkey, 0, content_b_v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_b0);
+    assert!(
+        status.is_ok(),
+        "Tx0 create B failed: {status:?}\nlogs:\n{}",
+        logs.join("\n"),
+    );
+
+    // Advance so the main tx loads B fresh.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for main tx");
+
+    // Main tx — ix0 creates A, ix1 loads + overwrites existing B. Two
+    // instructions, one transaction; the subaccount lane accumulates both in
+    // call order (A then B).
+    let ix_create_a =
+        subaccount_create_instruction(program_id, base_a, payer_pubkey, 0, content_a, vec![]);
+    let ix_load_b = subaccount_instruction(program_id, base_b, true, 1, content_b_v2, vec![]);
+    let tx = Transaction::new_signed_with_payer(
+        &[ix_create_a, ix_load_b],
+        Some(&payer_pubkey),
+        &[&mint_keypair],
+        bank.last_blockhash(),
+    );
+    let head = tx.message.account_keys.len();
+
+    let tx_batch = bank.prepare_batch_for_tests(vec![tx]);
+    let (mut commit_results, balance_collector) = bank.load_execute_and_commit_transactions(
+        &tx_batch,
+        MAX_PROCESSING_AGE,
+        ExecutionRecordingConfig {
+            enable_cpi_recording: false,
+            enable_log_recording: true,
+            enable_return_data_recording: false,
+            enable_transaction_balance_recording: true,
+        },
+        &mut ExecuteTimings::default(),
+        None,
+    );
+
+    let committed = commit_results.pop().unwrap().expect("main tx must commit");
+    assert!(
+        committed.status.is_ok(),
+        "main tx failed: {:?}\nlogs:\n{}",
+        committed.status,
+        committed
+            .log_messages
+            .clone()
+            .unwrap_or_default()
+            .join("\n"),
+    );
+
+    let balance_collector =
+        balance_collector.expect("balance recording was enabled, collector must exist");
+    let (balances, _token_balances, subaccount_keys, _unchanged_subaccount_keys) =
+        compile_collected_balances(balance_collector);
+
+    let owner_a =
+        create_subaccount_address(&[base_a.as_ref(), SUBACCOUNT_SEED_TAG], &program_id).unwrap();
+    let owner_b =
+        create_subaccount_address(&[base_b.as_ref(), SUBACCOUNT_SEED_TAG], &program_id).unwrap();
+
+    let pre = &balances.pre_balances[0];
+    let post = &balances.post_balances[0];
+
+    // Build the receipt meta exactly as the status service does.
+    let meta = TransactionStatusMeta {
+        status: committed.status.clone(),
+        pre_balances: pre.clone(),
+        post_balances: post.clone(),
+        subaccount_addresses: subaccount_keys[0].clone(),
+        ..TransactionStatusMeta::default()
+    };
+
+    // (1) Two subaccounts touched ⇒ two addresses in the receipt.
+    assert_eq!(
+        meta.subaccount_addresses.len(),
+        2,
+        "a tx touching two subaccounts must record two addresses, got {:?}",
+        meta.subaccount_addresses,
+    );
+
+    // (2) Lane order: A (created) first, then B (existing).
+    assert_eq!(
+        meta.subaccount_addresses,
+        vec![owner_a, owner_b],
+        "subaccount_addresses must be in lane order: created-then-loaded",
+    );
+
+    // (3) Address[i] corresponds to (pre_balances[head + i], post_balances[head + i]).
+    assert_eq!(pre.len(), head + 2, "two subaccount pre tail entries");
+    assert_eq!(post.len(), head + 2);
+    // A (index 0): created this tx ⇒ pre 0, post funded.
+    assert_eq!(
+        pre[head], 0,
+        "created subaccount A pre-balance must be 0 (did not exist pre-tx)",
+    );
+    assert_eq!(post[head], SUBACCOUNT_FUNDING_LAMPORTS);
+    // B (index 1): existed ⇒ pre funded; only data changed ⇒ post funded.
+    assert_eq!(
+        pre[head + 1],
+        SUBACCOUNT_FUNDING_LAMPORTS,
+        "existing subaccount B pre-balance must be its real pre-tx funding",
+    );
+    assert_eq!(post[head + 1], SUBACCOUNT_FUNDING_LAMPORTS);
+
+    // Both subaccounts persisted with their expected data.
+    let stored_a = bank
+        .get_account(&subaccount_storage_addr_for(&base_a, &program_id))
+        .expect("A must be on-chain");
+    assert_eq!(stored_a.data(), content_a);
+    let stored_b = bank
+        .get_account(&subaccount_storage_addr_for(&base_b, &program_id))
+        .expect("B must be on-chain");
+    assert_eq!(stored_b.data(), content_b_v2);
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -6814,3 +6814,142 @@ fn test_program_sbf_subaccount_read_only_does_not_restore() {
          (expected {tx2_slot}, got {mod_modified_slot})",
     );
 }
+
+/// PRS-155: end-to-end check that a subaccount-touching transaction surfaces
+/// its subaccount addresses through the balance-recording pipeline and into
+/// `TransactionStatusMeta` / `UiTransactionStatusMeta`.
+///
+/// Executes a real `sol_create_subaccount` + `sol_load_subaccount` tx with
+/// transaction balance recording enabled, then verifies:
+///   (a) `subaccount_addresses` is non-empty in the (Ui)meta;
+///   (b) the recorded address equals the owner-facing pubkey
+///       `sol_load_subaccount` derives from the seeds + program id;
+///   (c) the tail of `pre_balances`/`post_balances` (positions
+///       `[account_keys.len()..)`) lines up one-for-one with
+///       `subaccount_addresses`, carrying the subaccount's pre/post lamports.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_addresses_in_status_meta() {
+    use {
+        solana_ledger::transaction_balances::compile_collected_balances,
+        solana_transaction_context::create_subaccount_address,
+        solana_transaction_status::{
+            option_serializer::OptionSerializer, TransactionStatusMeta, UiTransactionStatusMeta,
+        },
+    };
+
+    let (bank, _bank_client, _bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let base_pubkey = Pubkey::new_unique();
+    let payer_pubkey = mint_keypair.pubkey();
+    let payload: &[u8] = b"subaccount-meta-payload";
+
+    // disc=0 — create + load + write + unload. The `sol_load_subaccount` here
+    // is what materializes the subaccount lane the balance collector reads.
+    let instruction =
+        subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, payload, vec![]);
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer_pubkey),
+        &[&mint_keypair],
+        bank.last_blockhash(),
+    );
+    let account_keys_len = tx.message.account_keys.len();
+
+    let tx_batch = bank.prepare_batch_for_tests(vec![tx]);
+    let (mut commit_results, balance_collector) = bank.load_execute_and_commit_transactions(
+        &tx_batch,
+        MAX_PROCESSING_AGE,
+        ExecutionRecordingConfig {
+            enable_cpi_recording: false,
+            enable_log_recording: true,
+            enable_return_data_recording: false,
+            enable_transaction_balance_recording: true,
+        },
+        &mut ExecuteTimings::default(),
+        None,
+    );
+
+    let committed = commit_results.pop().unwrap().expect("tx must commit");
+    let logs = committed.log_messages.clone().unwrap_or_default();
+    assert!(
+        committed.status.is_ok(),
+        "tx failed: {:?}\nlogs:\n{}",
+        committed.status,
+        logs.join("\n"),
+    );
+
+    let balance_collector =
+        balance_collector.expect("balance recording was enabled, collector must exist");
+    let (balances, _token_balances, subaccount_keys) =
+        compile_collected_balances(balance_collector);
+
+    // Single-transaction batch ⇒ index 0.
+    let pre_balances = &balances.pre_balances[0];
+    let post_balances = &balances.post_balances[0];
+    let tx_subaccount_keys = &subaccount_keys[0];
+
+    // (b) The recorded subaccount key is the owner-facing pubkey the program
+    // sees from `sol_load_subaccount`, derived from `[base, "test-sub"]`.
+    let expected_owner =
+        create_subaccount_address(&[base_pubkey.as_ref(), SUBACCOUNT_SEED_TAG], &program_id)
+            .expect("derive owner-facing subaccount pubkey");
+    assert_eq!(
+        tx_subaccount_keys,
+        &vec![expected_owner],
+        "balance collector must record exactly the touched subaccount's owner pubkey",
+    );
+
+    // (c) `pre_balances`/`post_balances` carry one tail entry per subaccount,
+    // appended after the `account_keys.len()` regular accounts, in the same
+    // order as `subaccount_keys`.
+    assert_eq!(
+        pre_balances.len(),
+        account_keys_len + tx_subaccount_keys.len(),
+        "pre_balances must extend the {account_keys_len} account-key slots with one entry per subaccount",
+    );
+    assert_eq!(
+        post_balances.len(),
+        pre_balances.len(),
+        "pre/post balance vectors must stay aligned",
+    );
+    // The subaccount is created in this tx, so its pre-lamports (read from the
+    // loader cache before `update_accounts_for_executed_tx`) are 0, and its
+    // post-lamports equal the funding the program transferred in.
+    assert_eq!(
+        &pre_balances[account_keys_len..],
+        &[0],
+        "subaccount pre-balance tail must be the pre-execution lamports (0 for a freshly created subaccount)",
+    );
+    assert_eq!(
+        &post_balances[account_keys_len..],
+        &[SUBACCOUNT_FUNDING_LAMPORTS],
+        "subaccount post-balance tail must be the funded lamports",
+    );
+
+    // (a) The addresses survive into the meta and its Ui projection.
+    let meta = TransactionStatusMeta {
+        status: committed.status.clone(),
+        pre_balances: pre_balances.clone(),
+        post_balances: post_balances.clone(),
+        subaccount_addresses: tx_subaccount_keys.clone(),
+        ..TransactionStatusMeta::default()
+    };
+    assert!(
+        !meta.subaccount_addresses.is_empty(),
+        "meta.subaccount_addresses must be populated for a subaccount-touching tx",
+    );
+
+    let ui_meta: UiTransactionStatusMeta = meta.into();
+    match ui_meta.subaccount_addresses {
+        OptionSerializer::Some(ref addrs) => {
+            assert_eq!(
+                addrs,
+                &vec![expected_owner.to_string()],
+                "Ui meta must expose the owner-facing subaccount address as a base58 string",
+            );
+        }
+        other => panic!("expected Ui subaccount_addresses to be Some, got {other:?}"),
+    }
+}

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -248,6 +248,7 @@ impl RpcSender for MockSender {
                             compute_units_consumed: OptionSerializer::Skip,
                             cost_units: OptionSerializer::Skip,
                             subaccount_addresses: OptionSerializer::Skip,
+                            unchanged_subaccount_addresses: OptionSerializer::Skip,
                         }),
                 },
                 block_time: Some(1628633791),

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -247,6 +247,7 @@ impl RpcSender for MockSender {
                             return_data: OptionSerializer::Skip,
                             compute_units_consumed: OptionSerializer::Skip,
                             cost_units: OptionSerializer::Skip,
+                            subaccount_addresses: OptionSerializer::Skip,
                         }),
                 },
                 block_time: Some(1628633791),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -138,6 +138,7 @@ impl TransactionStatusService {
                     token_balances,
                     costs,
                     transaction_indexes,
+                    subaccount_keys,
                 },
                 work_id,
             )) => {
@@ -156,6 +157,7 @@ impl TransactionStatusService {
                     post_token_balances,
                     cost,
                     transaction_index,
+                    subaccount_addresses,
                 ) in izip!(
                     transactions,
                     commit_results,
@@ -165,6 +167,7 @@ impl TransactionStatusService {
                     token_balances.post_token_balances,
                     costs,
                     transaction_indexes,
+                    subaccount_keys,
                 ) {
                     let Ok(committed_tx) = commit_result else {
                         continue;
@@ -203,6 +206,7 @@ impl TransactionStatusService {
                         return_data,
                         compute_units_consumed: Some(executed_units),
                         cost_units: cost,
+                        subaccount_addresses,
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
@@ -515,6 +519,7 @@ pub(crate) mod tests {
             token_balances,
             costs: vec![Some(123)],
             transaction_indexes: vec![transaction_index],
+            subaccount_keys: vec![vec![]],
         };
 
         let test_notifier = Arc::new(TestTransactionNotifier::new());
@@ -623,6 +628,7 @@ pub(crate) mod tests {
             token_balances,
             costs: vec![Some(123), Some(456)],
             transaction_indexes: vec![transaction_index1, transaction_index2],
+            subaccount_keys: vec![vec![], vec![]],
         };
 
         let test_notifier = Arc::new(TestTransactionNotifier::new());

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -139,6 +139,7 @@ impl TransactionStatusService {
                     costs,
                     transaction_indexes,
                     subaccount_keys,
+                    unchanged_subaccount_keys,
                 },
                 work_id,
             )) => {
@@ -158,6 +159,7 @@ impl TransactionStatusService {
                     cost,
                     transaction_index,
                     subaccount_addresses,
+                    unchanged_subaccount_addresses,
                 ) in izip!(
                     transactions,
                     commit_results,
@@ -168,6 +170,7 @@ impl TransactionStatusService {
                     costs,
                     transaction_indexes,
                     subaccount_keys,
+                    unchanged_subaccount_keys,
                 ) {
                     let Ok(committed_tx) = commit_result else {
                         continue;
@@ -207,6 +210,7 @@ impl TransactionStatusService {
                         compute_units_consumed: Some(executed_units),
                         cost_units: cost,
                         subaccount_addresses,
+                        unchanged_subaccount_addresses,
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
@@ -520,6 +524,7 @@ pub(crate) mod tests {
             costs: vec![Some(123)],
             transaction_indexes: vec![transaction_index],
             subaccount_keys: vec![vec![]],
+            unchanged_subaccount_keys: vec![vec![]],
         };
 
         let test_notifier = Arc::new(TestTransactionNotifier::new());
@@ -629,6 +634,7 @@ pub(crate) mod tests {
             costs: vec![Some(123), Some(456)],
             transaction_indexes: vec![transaction_index1, transaction_index2],
             subaccount_keys: vec![vec![], vec![]],
+            unchanged_subaccount_keys: vec![vec![], vec![]],
         };
 
         let test_notifier = Arc::new(TestTransactionNotifier::new());

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -11,7 +11,9 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    solana_transaction_context::{
+        subaccount_storage_address, transaction_accounts::KeyedAccountSharedData,
+    },
 };
 
 // Used to approximate how many accounts will be calculated for storage so that
@@ -53,7 +55,11 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
     txs_refs: &'a Option<Vec<impl Borrow<SanitizedTransaction>>>,
     processing_results: &'a [TransactionProcessingResult],
 ) -> (
-    Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    // F10/PRS-314: owned `Pubkey` (not `&Pubkey`) so subaccount tail entries
+    // can carry the derived `subaccount_storage_address(owner)` — that key is
+    // computed inline and has no stable backing storage. `Pubkey` is a 32-byte
+    // `Copy`, so non-subaccount entries are dereferenced for free.
+    Vec<(Pubkey, &'a AccountSharedData)>,
     Option<Vec<&'a SanitizedTransaction>>,
 ) {
     let collect_capacity = max_number_of_accounts_to_collect(txs, processing_results);
@@ -102,7 +108,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
 }
 
 fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
-    collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    collected_accounts: &mut Vec<(Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
@@ -121,25 +127,29 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
             continue;
         }
 
-        collected_accounts.push((address, account));
+        collected_accounts.push((*address, account));
         if let Some(collected_account_transactions) = collected_account_transactions {
             collected_account_transactions
                 .push(transaction_ref.expect("transaction ref must exist if collecting"));
         }
     }
 
-    // F10 W10: subaccount lane entries appended by
-    // `TransactionAccounts::deconstruct_into_keyed_account_shared_data`
-    // sit after `transaction.account_keys().len()`. They are always
-    // writable and not part of the original tx account list, so the
-    // `is_writable` / `is_invoked` checks above do not apply — persist
-    // them unconditionally so accounts-db carries subaccount state to
-    // subsequent transactions. Mirrors the parasol-dev account_saver.
-    for (address, account) in transaction_accounts
+    // F10 W10 / PRS-314: subaccount lane entries appended by
+    // `TransactionAccounts::deconstruct_into_keyed_account_shared_data` sit
+    // after `transaction.account_keys().len()` and are keyed by the
+    // owner-facing pubkey. Apply `subaccount_storage_address` here at the
+    // accounts-db boundary so the on-disk entry lives under the hashed
+    // address (preventing collisions with regular user accounts) while the
+    // lane stays addressable by owner pubkey for the recipe / balance
+    // collector. They are always writable and not part of the original tx
+    // account list, so the `is_writable` / `is_invoked` checks above do not
+    // apply — persist them unconditionally so accounts-db carries subaccount
+    // state to subsequent transactions.
+    for (owner_address, account) in transaction_accounts
         .iter()
         .skip(transaction.account_keys().len())
     {
-        collected_accounts.push((address, account));
+        collected_accounts.push((subaccount_storage_address(owner_address), account));
         if let Some(collected_account_transactions) = collected_account_transactions {
             collected_account_transactions
                 .push(transaction_ref.expect("transaction ref must exist if collecting"));
@@ -148,13 +158,13 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
 }
 
 fn collect_accounts_for_failed_tx<'a>(
-    collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
+    collected_accounts: &mut Vec<(Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,
     transaction_ref: Option<&'a SanitizedTransaction>,
     rollback_accounts: &'a RollbackAccounts,
 ) {
     for (address, account) in rollback_accounts {
-        collected_accounts.push((address, account));
+        collected_accounts.push((*address, account));
         if let Some(collected_account_transactions) = collected_account_transactions {
             collected_account_transactions
                 .push(transaction_ref.expect("transaction ref must exist if collecting"));
@@ -294,10 +304,10 @@ mod tests {
             assert_eq!(collected_accounts.len(), 2);
             assert!(collected_accounts
                 .iter()
-                .any(|(pubkey, _account)| *pubkey == &keypair0.pubkey()));
+                .any(|(pubkey, _account)| *pubkey == keypair0.pubkey()));
             assert!(collected_accounts
                 .iter()
-                .any(|(pubkey, _account)| *pubkey == &keypair1.pubkey()));
+                .any(|(pubkey, _account)| *pubkey == keypair1.pubkey()));
 
             if collect_transactions {
                 let transactions = transactions.unwrap();
@@ -359,7 +369,7 @@ mod tests {
             assert_eq!(
                 collected_accounts
                     .iter()
-                    .find(|(pubkey, _account)| *pubkey == &from_address)
+                    .find(|(pubkey, _account)| *pubkey == from_address)
                     .map(|(_pubkey, account)| *account)
                     .cloned()
                     .unwrap(),
@@ -451,7 +461,7 @@ mod tests {
             assert_eq!(
                 collected_accounts
                     .iter()
-                    .find(|(pubkey, _account)| *pubkey == &from_address)
+                    .find(|(pubkey, _account)| *pubkey == from_address)
                     .map(|(_pubkey, account)| *account)
                     .cloned()
                     .unwrap(),
@@ -459,7 +469,7 @@ mod tests {
             );
             let collected_nonce_account = collected_accounts
                 .iter()
-                .find(|(pubkey, _account)| *pubkey == &nonce_address)
+                .find(|(pubkey, _account)| *pubkey == nonce_address)
                 .map(|(_pubkey, account)| *account)
                 .cloned()
                 .unwrap();
@@ -555,7 +565,7 @@ mod tests {
             assert_eq!(collected_accounts.len(), 1);
             let collected_nonce_account = collected_accounts
                 .iter()
-                .find(|(pubkey, _account)| *pubkey == &nonce_address)
+                .find(|(pubkey, _account)| *pubkey == nonce_address)
                 .map(|(_pubkey, account)| *account)
                 .cloned()
                 .unwrap();
@@ -612,7 +622,7 @@ mod tests {
             assert_eq!(
                 collected_accounts
                     .iter()
-                    .find(|(pubkey, _account)| *pubkey == &from_address)
+                    .find(|(pubkey, _account)| *pubkey == from_address)
                     .map(|(_pubkey, account)| *account)
                     .cloned()
                     .unwrap(),

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -225,6 +225,7 @@ mod tests {
                     return_data: None,
                     executed_units: 0,
                     accounts_data_len_delta: 0,
+                    unchanged_subaccount_addresses: Vec::new(),
                 },
                 loaded_transaction,
                 programs_modified_by_tx: HashMap::new(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3194,8 +3194,13 @@ impl Bank {
         let (pre_balances, post_balances, pre_token_balances, post_token_balances) =
             match balance_collector {
                 Some(balance_collector) => {
-                    let (mut native_pre, mut native_post, mut token_pre, mut token_post) =
-                        balance_collector.into_vecs();
+                    let (
+                        mut native_pre,
+                        mut native_post,
+                        mut token_pre,
+                        mut token_post,
+                        _subaccount_keys,
+                    ) = balance_collector.into_vecs();
 
                     (
                         native_pre.pop(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3200,6 +3200,7 @@ impl Bank {
                         mut token_pre,
                         mut token_post,
                         _subaccount_keys,
+                        _unchanged_subaccount_keys,
                     ) = balance_collector.into_vecs();
 
                     (

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -246,6 +246,7 @@ fn new_executed_processing_result(
                 return_data: None,
                 executed_units: 0,
                 accounts_data_len_delta: 0,
+                unchanged_subaccount_addresses: Vec::new(),
             },
             programs_modified_by_tx: HashMap::new(),
         },
@@ -4895,7 +4896,7 @@ fn test_pre_post_transaction_balances() {
         None,
     );
 
-    let (native_pre, native_post, _, _, _) = balance_collector.unwrap().into_vecs();
+    let (native_pre, native_post, _, _, _, _) = balance_collector.unwrap().into_vecs();
     let transaction_balances_set = TransactionBalancesSet::new(native_pre, native_post);
 
     assert_eq!(transaction_balances_set.pre_balances.len(), 3);
@@ -11648,8 +11649,7 @@ fn test_system_zero_lamport_empty_account_is_hidden_and_cleaned() {
     let slot2 = bank1.slot() + 1;
     let bank2 =
         Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, &collector, slot2);
-    let zero_system_account =
-        AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id());
+    let zero_system_account = AccountSharedData::new(0, 0, &solana_sdk_ids::system_program::id());
     bank2.store_account(&account_key, &zero_system_account);
 
     assert_eq!(bank2.get_account(&account_key), None);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4895,7 +4895,7 @@ fn test_pre_post_transaction_balances() {
         None,
     );
 
-    let (native_pre, native_post, _, _) = balance_collector.unwrap().into_vecs();
+    let (native_pre, native_post, _, _, _) = balance_collector.unwrap().into_vecs();
     let transaction_balances_set = TransactionBalancesSet::new(native_pre, native_post);
 
     assert_eq!(transaction_balances_set.pre_balances.len(), 3);

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1026,6 +1026,7 @@ mod tests {
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: Some(1234),
                 cost_units: Some(5678),
+                subaccount_addresses: vec![],
             },
         });
         let expected_block = ConfirmedBlock {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1027,6 +1027,7 @@ mod tests {
                 compute_units_consumed: Some(1234),
                 cost_units: Some(5678),
                 subaccount_addresses: vec![],
+                unchanged_subaccount_addresses: vec![],
             },
         });
         let expected_block = ConfirmedBlock {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -265,6 +265,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed: None,
             cost_units: None,
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -264,6 +264,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            subaccount_addresses: vec![],
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -68,12 +68,17 @@ message TransactionStatusMeta {
     // Total transaction cost
     optional uint64 cost_units = 17;
 
-    // F10/PRS-314: owner-facing pubkeys of subaccounts touched by this
+    // F10/PRS-314: owner-facing pubkeys of subaccounts *changed* by this
     // transaction, in the same order as the tail of `pre_balances`/
     // `post_balances` (positions [account_keys.len()..)). Empty for
-    // transactions that don't use subaccounts. Always-empty for txs
+    // transactions that don't change a subaccount. Always-empty for txs
     // committed by older nodes (proto3 default).
-    repeated bytes subaccount_addresses = 18;
+    repeated bytes subaccount_addresses = 200;
+
+    // F10/PRS-155: owner-facing pubkeys of subaccounts accessed but left
+    // *unchanged* (read-only). Reported by address only — no associated
+    // pre/post balances. Always-empty for txs committed by older nodes.
+    repeated bytes unchanged_subaccount_addresses = 201;
 }
 
 message TransactionError {

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -67,6 +67,13 @@ message TransactionStatusMeta {
     optional uint64 compute_units_consumed = 16;
     // Total transaction cost
     optional uint64 cost_units = 17;
+
+    // F10/PRS-314: owner-facing pubkeys of subaccounts touched by this
+    // transaction, in the same order as the tail of `pre_balances`/
+    // `post_balances` (positions [account_keys.len()..)). Empty for
+    // transactions that don't use subaccounts. Always-empty for txs
+    // committed by older nodes (proto3 default).
+    repeated bytes subaccount_addresses = 18;
 }
 
 message TransactionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -423,6 +423,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         } = value;
         let err = match status {
             Ok(()) => None,
@@ -469,6 +470,10 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             .into_iter()
             .map(|key| <Pubkey as AsRef<[u8]>>::as_ref(&key).into())
             .collect();
+        let unchanged_subaccount_addresses = unchanged_subaccount_addresses
+            .into_iter()
+            .map(|key| <Pubkey as AsRef<[u8]>>::as_ref(&key).into())
+            .collect();
 
         Self {
             err,
@@ -489,6 +494,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         }
     }
 }
@@ -523,6 +529,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -587,6 +594,14 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
                 let err = format!("Invalid subaccount address: {err:?}");
                 Self::Error::new(bincode::ErrorKind::Custom(err))
             })?;
+        let unchanged_subaccount_addresses = unchanged_subaccount_addresses
+            .into_iter()
+            .map(Pubkey::try_from)
+            .collect::<Result<_, _>>()
+            .map_err(|err| {
+                let err = format!("Invalid unchanged subaccount address: {err:?}");
+                Self::Error::new(bincode::ErrorKind::Custom(err))
+            })?;
         Ok(Self {
             status,
             fee,
@@ -602,6 +617,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         })
     }
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -422,6 +422,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         } = value;
         let err = match status {
             Ok(()) => None,
@@ -464,6 +465,10 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             .collect();
         let return_data_none = return_data.is_none();
         let return_data = return_data.map(|return_data| return_data.into());
+        let subaccount_addresses = subaccount_addresses
+            .into_iter()
+            .map(|key| <Pubkey as AsRef<[u8]>>::as_ref(&key).into())
+            .collect();
 
         Self {
             err,
@@ -483,6 +488,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data_none,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         }
     }
 }
@@ -516,6 +522,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data_none,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -572,6 +579,14 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
         } else {
             return_data.map(|return_data| return_data.into())
         };
+        let subaccount_addresses = subaccount_addresses
+            .into_iter()
+            .map(Pubkey::try_from)
+            .collect::<Result<_, _>>()
+            .map_err(|err| {
+                let err = format!("Invalid subaccount address: {err:?}");
+                Self::Error::new(bincode::ErrorKind::Custom(err))
+            })?;
         Ok(Self {
             status,
             fee,
@@ -586,6 +601,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         })
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -210,6 +210,10 @@ pub struct StoredTransactionStatusMeta {
     // old bincode blobs deserialize this as an empty Vec.
     #[serde(default, deserialize_with = "default_on_eof")]
     pub subaccount_addresses: Vec<Pubkey>,
+    // F10/PRS-155: unchanged (read-only) subaccount owner keys. Also appended
+    // backward-compatibly — old blobs deserialize this as an empty Vec.
+    #[serde(default, deserialize_with = "default_on_eof")]
+    pub unchanged_subaccount_addresses: Vec<Pubkey>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -228,6 +232,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         } = value;
         Self {
             status,
@@ -247,6 +252,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         }
     }
 }
@@ -269,6 +275,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -296,6 +303,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             compute_units_consumed,
             cost_units,
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         })
     }
 }
@@ -408,7 +416,10 @@ mod tests {
     // contract: new blobs round-trip the addresses, and old blobs written
     // before the field existed (i.e. the byte stream ends right after
     // `cost_units`) still deserialize, defaulting the field to an empty Vec.
-    fn stored_meta_with(subaccount_addresses: Vec<solana_pubkey::Pubkey>) -> StoredTransactionStatusMeta {
+    fn stored_meta_with(
+        subaccount_addresses: Vec<solana_pubkey::Pubkey>,
+        unchanged_subaccount_addresses: Vec<solana_pubkey::Pubkey>,
+    ) -> StoredTransactionStatusMeta {
         StoredTransactionStatusMeta {
             status: Ok(()),
             fee: 42,
@@ -423,6 +434,7 @@ mod tests {
             compute_units_consumed: Some(1234),
             cost_units: Some(5678),
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         }
     }
 
@@ -434,29 +446,42 @@ mod tests {
             Pubkey::new_from_array([7u8; 32]),
             Pubkey::new_from_array([9u8; 32]),
         ];
-        let bytes = bincode::serialize(&stored_meta_with(subaccount_addresses.clone())).unwrap();
+        let unchanged_subaccount_addresses = vec![Pubkey::new_from_array([11u8; 32])];
+        let bytes = bincode::serialize(&stored_meta_with(
+            subaccount_addresses.clone(),
+            unchanged_subaccount_addresses.clone(),
+        ))
+        .unwrap();
         let decoded: StoredTransactionStatusMeta = bincode::deserialize(&bytes).unwrap();
         assert_eq!(decoded.subaccount_addresses, subaccount_addresses);
+        assert_eq!(
+            decoded.unchanged_subaccount_addresses,
+            unchanged_subaccount_addresses
+        );
     }
 
     #[test]
     fn test_stored_transaction_status_meta_old_blob_defaults_subaccount_addresses() {
-        // An empty trailing Vec encodes as an 8-byte length prefix of 0. Since
-        // `subaccount_addresses` is the final field, stripping those 8 bytes
-        // reproduces the exact byte stream an old node (without the field)
-        // would have written.
-        let bytes = bincode::serialize(&stored_meta_with(vec![])).unwrap();
-        let (old_blob, length_prefix) = bytes.split_at(bytes.len() - 8);
+        // Each empty trailing Vec encodes as an 8-byte length prefix of 0.
+        // `subaccount_addresses` and `unchanged_subaccount_addresses` are the
+        // last two fields, so stripping those 16 bytes reproduces the exact
+        // byte stream an old node (without either field) would have written.
+        let bytes = bincode::serialize(&stored_meta_with(vec![], vec![])).unwrap();
+        let (old_blob, length_prefixes) = bytes.split_at(bytes.len() - 16);
         assert_eq!(
-            length_prefix,
-            &[0u8; 8],
-            "an empty subaccount_addresses Vec must encode as a zero u64 length prefix",
+            length_prefixes,
+            &[0u8; 16],
+            "two empty trailing Vecs must encode as two zero u64 length prefixes",
         );
 
         let decoded: StoredTransactionStatusMeta = bincode::deserialize(old_blob).unwrap();
         assert!(
             decoded.subaccount_addresses.is_empty(),
             "old blobs must deserialize with an empty subaccount_addresses Vec",
+        );
+        assert!(
+            decoded.unchanged_subaccount_addresses.is_empty(),
+            "old blobs must deserialize with an empty unchanged_subaccount_addresses Vec",
         );
         // The rest of the meta must survive the truncated decode intact.
         assert_eq!(decoded.fee, 42);
@@ -471,7 +496,16 @@ mod tests {
         use {solana_pubkey::Pubkey, solana_transaction_status::TransactionStatusMeta};
 
         let subaccount_addresses = vec![Pubkey::new_from_array([3u8; 32])];
-        let meta: TransactionStatusMeta = stored_meta_with(subaccount_addresses.clone()).into();
+        let unchanged_subaccount_addresses = vec![Pubkey::new_from_array([4u8; 32])];
+        let meta: TransactionStatusMeta = stored_meta_with(
+            subaccount_addresses.clone(),
+            unchanged_subaccount_addresses.clone(),
+        )
+        .into();
         assert_eq!(meta.subaccount_addresses, subaccount_addresses);
+        assert_eq!(
+            meta.unchanged_subaccount_addresses,
+            unchanged_subaccount_addresses
+        );
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -14,6 +14,7 @@ use {
         StringAmount,
     },
     solana_message::v0::LoadedAddresses,
+    solana_pubkey::Pubkey,
     solana_serde::default_on_eof,
     solana_transaction_context::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
@@ -205,6 +206,10 @@ pub struct StoredTransactionStatusMeta {
     pub compute_units_consumed: Option<u64>,
     #[serde(deserialize_with = "default_on_eof")]
     pub cost_units: Option<u64>,
+    // F10/PRS-314: appended in a backward-compatible way via default_on_eof;
+    // old bincode blobs deserialize this as an empty Vec.
+    #[serde(default, deserialize_with = "default_on_eof")]
+    pub subaccount_addresses: Vec<Pubkey>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -222,6 +227,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         } = value;
         Self {
             status,
@@ -240,6 +246,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         }
     }
 }
@@ -261,6 +268,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -287,6 +295,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            subaccount_addresses,
         })
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -303,8 +303,10 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
 #[cfg(test)]
 mod tests {
     use {
-        crate::StoredTransactionError, solana_instruction::error::InstructionError,
-        solana_transaction_error::TransactionError, test_case::test_case,
+        crate::{StoredTransactionError, StoredTransactionStatusMeta},
+        solana_instruction::error::InstructionError,
+        solana_transaction_error::TransactionError,
+        test_case::test_case,
     };
 
     #[test_case(TransactionError::InsufficientFundsForFee; "Named variant error")]
@@ -398,5 +400,78 @@ mod tests {
     ) {
         let StoredTransactionError(serialized_bytes) = transaction_error.into();
         assert_eq!(serialized_bytes, expected_serialized_bytes);
+    }
+
+    // PRS-155: `subaccount_addresses` is appended last in
+    // `StoredTransactionStatusMeta` with `#[serde(default, deserialize_with =
+    // "default_on_eof")]`. These tests pin both directions of the wire
+    // contract: new blobs round-trip the addresses, and old blobs written
+    // before the field existed (i.e. the byte stream ends right after
+    // `cost_units`) still deserialize, defaulting the field to an empty Vec.
+    fn stored_meta_with(subaccount_addresses: Vec<solana_pubkey::Pubkey>) -> StoredTransactionStatusMeta {
+        StoredTransactionStatusMeta {
+            status: Ok(()),
+            fee: 42,
+            pre_balances: vec![1, 2, 3],
+            post_balances: vec![4, 5, 6],
+            inner_instructions: None,
+            log_messages: None,
+            pre_token_balances: None,
+            post_token_balances: None,
+            rewards: None,
+            return_data: None,
+            compute_units_consumed: Some(1234),
+            cost_units: Some(5678),
+            subaccount_addresses,
+        }
+    }
+
+    #[test]
+    fn test_stored_transaction_status_meta_subaccount_addresses_round_trip() {
+        use solana_pubkey::Pubkey;
+
+        let subaccount_addresses = vec![
+            Pubkey::new_from_array([7u8; 32]),
+            Pubkey::new_from_array([9u8; 32]),
+        ];
+        let bytes = bincode::serialize(&stored_meta_with(subaccount_addresses.clone())).unwrap();
+        let decoded: StoredTransactionStatusMeta = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.subaccount_addresses, subaccount_addresses);
+    }
+
+    #[test]
+    fn test_stored_transaction_status_meta_old_blob_defaults_subaccount_addresses() {
+        // An empty trailing Vec encodes as an 8-byte length prefix of 0. Since
+        // `subaccount_addresses` is the final field, stripping those 8 bytes
+        // reproduces the exact byte stream an old node (without the field)
+        // would have written.
+        let bytes = bincode::serialize(&stored_meta_with(vec![])).unwrap();
+        let (old_blob, length_prefix) = bytes.split_at(bytes.len() - 8);
+        assert_eq!(
+            length_prefix,
+            &[0u8; 8],
+            "an empty subaccount_addresses Vec must encode as a zero u64 length prefix",
+        );
+
+        let decoded: StoredTransactionStatusMeta = bincode::deserialize(old_blob).unwrap();
+        assert!(
+            decoded.subaccount_addresses.is_empty(),
+            "old blobs must deserialize with an empty subaccount_addresses Vec",
+        );
+        // The rest of the meta must survive the truncated decode intact.
+        assert_eq!(decoded.fee, 42);
+        assert_eq!(decoded.pre_balances, vec![1, 2, 3]);
+        assert_eq!(decoded.post_balances, vec![4, 5, 6]);
+        assert_eq!(decoded.compute_units_consumed, Some(1234));
+        assert_eq!(decoded.cost_units, Some(5678));
+    }
+
+    #[test]
+    fn test_stored_transaction_status_meta_to_status_meta_preserves_subaccounts() {
+        use {solana_pubkey::Pubkey, solana_transaction_status::TransactionStatusMeta};
+
+        let subaccount_addresses = vec![Pubkey::new_from_array([3u8; 32])];
+        let meta: TransactionStatusMeta = stored_meta_with(subaccount_addresses.clone()).into();
+        assert_eq!(meta.subaccount_addresses, subaccount_addresses);
     }
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -35,7 +35,9 @@ use {
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::{transaction_accounts::KeyedAccountSharedData, IndexOfAccount},
+    solana_transaction_context::{
+        subaccount_storage_address, transaction_accounts::KeyedAccountSharedData, IndexOfAccount,
+    },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::num::{NonZeroU32, Saturating},
 };
@@ -153,6 +155,13 @@ pub(crate) struct LoadedTransactionAccount {
     field_qualifiers(program_indices(pub), compute_budget(pub))
 )]
 pub struct LoadedTransaction {
+    /// Account values for the transaction. Indices
+    /// `[0..message.account_keys().len())` correspond to the message account
+    /// keys; the tail `[message.account_keys().len()..)` is the subaccount
+    /// lane, keyed by the **owner-facing** pubkey. The accounts-db storage
+    /// address (`subaccount_storage_address(owner)`) is applied at the
+    /// commit boundary by `account_saver::collect_accounts_to_store` and
+    /// matched on lookup by `AccountLoader::update_accounts_for_successful_tx`.
     pub accounts: Vec<KeyedAccountSharedData>,
     pub(crate) program_indices: Vec<IndexOfAccount>,
     pub fee_details: FeeDetails,
@@ -344,14 +353,22 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
 
             self.loaded_accounts.insert(*address, account.clone());
         }
-        for (address, account) in transaction_accounts
+        // F10/PRS-314: subaccount tail is keyed by the owner-facing pubkey;
+        // accounts-db addresses subaccounts by
+        // `subaccount_storage_address(owner)`, so apply the transform here at
+        // the cache-write boundary so subsequent
+        // `load_account(&storage_address(owner))` calls hit post-execution
+        // state.
+        for (owner_address, account) in transaction_accounts
             .iter()
             .skip(message.account_keys().len())
         {
-            self.loaded_accounts.insert(*address, account.clone());
+            self.loaded_accounts.insert(
+                subaccount_storage_address(owner_address),
+                account.clone(),
+            );
         }
     }
-
 }
 
 // Program loaders and parsers require a type that impls TransactionProcessingCallback,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -363,10 +363,8 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             .iter()
             .skip(message.account_keys().len())
         {
-            self.loaded_accounts.insert(
-                subaccount_storage_address(owner_address),
-                account.clone(),
-            );
+            self.loaded_accounts
+                .insert(subaccount_storage_address(owner_address), account.clone());
         }
     }
 }

--- a/svm/src/transaction_balances.rs
+++ b/svm/src/transaction_balances.rs
@@ -192,14 +192,18 @@ impl BalanceCollectionRoutines for BalanceCollector {
             return;
         }
 
-        let pre_tail = self
-            .native_pre
-            .last_mut()
-            .expect("collect_subaccount_pre_balances called without collect_pre_balances");
-        let subaccount_keys_tail = self
-            .subaccount_keys
-            .last_mut()
-            .expect("collect_subaccount_pre_balances called without collect_pre_balances");
+        let (Some(pre_tail), Some(subaccount_keys_tail)) =
+            (self.native_pre.last_mut(), self.subaccount_keys.last_mut())
+        else {
+            // `collect_pre_balances` seeds both tails for every tx, so a missing
+            // tail here means it was skipped — a caller bug. Assert loudly in
+            // debug builds, but don't panic the validator hot path in release.
+            debug_assert!(
+                false,
+                "collect_subaccount_pre_balances called without collect_pre_balances"
+            );
+            return;
+        };
         for (owner_pubkey, _) in subaccount_lane.iter() {
             // The lane is keyed by the owner-facing pubkey;
             // `subaccount_storage_address` is the accounts-db addressing of

--- a/svm/src/transaction_balances.rs
+++ b/svm/src/transaction_balances.rs
@@ -50,6 +50,7 @@ pub(crate) trait BalanceCollectionRoutines {
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
         subaccount_lane: &[KeyedAccountSharedData],
+        unchanged_subaccount_addresses: &[Pubkey],
     );
 }
 
@@ -62,6 +63,7 @@ pub(crate) trait BalanceCollectionRoutines {
         token_pre(pub),
         token_post(pub),
         subaccount_keys(pub),
+        unchanged_subaccount_keys(pub),
     )
 )]
 pub struct BalanceCollector {
@@ -69,11 +71,15 @@ pub struct BalanceCollector {
     native_post: BatchNativeBalances,
     token_pre: BatchTokenBalances,
     token_post: BatchTokenBalances,
-    // F10/PRS-314: per-transaction owner-facing pubkeys of subaccounts touched
+    // F10/PRS-314: per-transaction owner-facing pubkeys of subaccounts *changed*
     // during execution, in the same order as the tail of `native_pre` /
     // `native_post` (positions [account_keys.len()..)). Empty for txs that
-    // didn't use subaccounts.
+    // didn't change any subaccount.
     subaccount_keys: BatchSubaccountKeys,
+    // F10/PRS-155: per-transaction owner-facing pubkeys of subaccounts that
+    // were accessed but left *unchanged* (read-only reads/loads). These carry
+    // no pre/post balances — the receipt lists them by owner address only.
+    unchanged_subaccount_keys: BatchSubaccountKeys,
 }
 
 impl BalanceCollector {
@@ -85,6 +91,7 @@ impl BalanceCollector {
             token_pre: Vec::with_capacity(transaction_count),
             token_post: Vec::with_capacity(transaction_count),
             subaccount_keys: Vec::with_capacity(transaction_count),
+            unchanged_subaccount_keys: Vec::with_capacity(transaction_count),
         }
     }
 
@@ -98,6 +105,7 @@ impl BalanceCollector {
         BatchTokenBalances,
         BatchTokenBalances,
         BatchSubaccountKeys,
+        BatchSubaccountKeys,
     ) {
         (
             self.native_pre,
@@ -105,6 +113,7 @@ impl BalanceCollector {
             self.token_pre,
             self.token_post,
             self.subaccount_keys,
+            self.unchanged_subaccount_keys,
         )
     }
 
@@ -150,6 +159,7 @@ impl BalanceCollector {
             && self.token_pre.len() == expected_len
             && self.token_post.len() == expected_len
             && self.subaccount_keys.len() == expected_len
+            && self.unchanged_subaccount_keys.len() == expected_len
     }
 }
 
@@ -168,6 +178,9 @@ impl BalanceCollectionRoutines for BalanceCollector {
         // are appended in `collect_subaccount_pre_balances` /
         // `collect_post_balances` below.
         self.subaccount_keys.push(Vec::new());
+        // Unchanged subaccounts are recorded in `collect_post_balances` (owner
+        // keys only); seed the per-tx slot here to keep batch lengths aligned.
+        self.unchanged_subaccount_keys.push(Vec::new());
     }
 
     fn collect_subaccount_pre_balances<CB: TransactionProcessingCallback>(
@@ -210,6 +223,7 @@ impl BalanceCollectionRoutines for BalanceCollector {
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
         subaccount_lane: &[KeyedAccountSharedData],
+        unchanged_subaccount_addresses: &[Pubkey],
     ) {
         let (mut native_balances, token_balances) =
             self.collect_balances(account_loader, transaction);
@@ -226,6 +240,15 @@ impl BalanceCollectionRoutines for BalanceCollector {
 
         self.native_post.push(native_balances);
         self.token_post.push(token_balances);
+
+        // F10/PRS-155: record the read-only (unchanged) subaccounts by owner
+        // key only — no balance is appended to native_pre/native_post for
+        // them. The per-tx slot was seeded in `collect_pre_balances`.
+        if !unchanged_subaccount_addresses.is_empty() {
+            if let Some(tail) = self.unchanged_subaccount_keys.last_mut() {
+                tail.extend_from_slice(unchanged_subaccount_addresses);
+            }
+        }
     }
 }
 
@@ -255,9 +278,15 @@ impl BalanceCollectionRoutines for Option<BalanceCollector> {
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
         subaccount_lane: &[KeyedAccountSharedData],
+        unchanged_subaccount_addresses: &[Pubkey],
     ) {
         if let Some(inner) = self {
-            inner.collect_post_balances(account_loader, transaction, subaccount_lane)
+            inner.collect_post_balances(
+                account_loader,
+                transaction,
+                subaccount_lane,
+                unchanged_subaccount_addresses,
+            )
         }
     }
 }

--- a/svm/src/transaction_balances.rs
+++ b/svm/src/transaction_balances.rs
@@ -8,14 +8,19 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_pubkey::Pubkey,
     solana_svm_transaction::svm_transaction::SVMTransaction,
+    solana_transaction_context::{
+        subaccount_storage_address, transaction_accounts::KeyedAccountSharedData,
+    },
     spl_generic_token::{generic_token, is_known_spl_token_id},
 };
 
 // we use internal aliases for clarity, the external type aliases are often confusing
 type TxNativeBalances = Vec<u64>;
 type TxTokenBalances = Vec<SvmTokenInfo>;
+type TxSubaccountKeys = Vec<Pubkey>;
 type BatchNativeBalances = Vec<TxNativeBalances>;
 type BatchTokenBalances = Vec<TxTokenBalances>;
+type BatchSubaccountKeys = Vec<TxSubaccountKeys>;
 
 // to operate cleanly over Option<BalanceCollector> we use a trait impled on the outer and inner type
 pub(crate) trait BalanceCollectionRoutines {
@@ -25,23 +30,50 @@ pub(crate) trait BalanceCollectionRoutines {
         transaction: &impl SVMTransaction,
     );
 
+    /// F10/PRS-314: capture subaccount pre-balances **after execution but
+    /// before** `AccountLoader::update_accounts_for_executed_tx` runs, so the
+    /// loader cache still returns the pre-execution state for the subaccount
+    /// storage address. The lane is keyed by the owner-facing pubkey;
+    /// `subaccount_storage_address` is applied here only to read pre-state
+    /// out of the loader cache. Extends the tail of the per-tx native_pre
+    /// vector with pre-lamports and records the owner pubkeys in
+    /// `subaccount_keys`. Subaccount post values are appended later in
+    /// `collect_post_balances` directly from the lane.
+    fn collect_subaccount_pre_balances<CB: TransactionProcessingCallback>(
+        &mut self,
+        account_loader: &mut AccountLoader<CB>,
+        subaccount_lane: &[KeyedAccountSharedData],
+    );
+
     fn collect_post_balances<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
+        subaccount_lane: &[KeyedAccountSharedData],
     );
 }
 
 #[derive(Debug, Default)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
-    field_qualifiers(native_pre(pub), native_post(pub), token_pre(pub), token_post(pub),)
+    field_qualifiers(
+        native_pre(pub),
+        native_post(pub),
+        token_pre(pub),
+        token_post(pub),
+        subaccount_keys(pub),
+    )
 )]
 pub struct BalanceCollector {
     native_pre: BatchNativeBalances,
     native_post: BatchNativeBalances,
     token_pre: BatchTokenBalances,
     token_post: BatchTokenBalances,
+    // F10/PRS-314: per-transaction owner-facing pubkeys of subaccounts touched
+    // during execution, in the same order as the tail of `native_pre` /
+    // `native_post` (positions [account_keys.len()..)). Empty for txs that
+    // didn't use subaccounts.
+    subaccount_keys: BatchSubaccountKeys,
 }
 
 impl BalanceCollector {
@@ -52,6 +84,7 @@ impl BalanceCollector {
             native_post: Vec::with_capacity(transaction_count),
             token_pre: Vec::with_capacity(transaction_count),
             token_post: Vec::with_capacity(transaction_count),
+            subaccount_keys: Vec::with_capacity(transaction_count),
         }
     }
 
@@ -64,12 +97,14 @@ impl BalanceCollector {
         BatchNativeBalances,
         BatchTokenBalances,
         BatchTokenBalances,
+        BatchSubaccountKeys,
     ) {
         (
             self.native_pre,
             self.native_post,
             self.token_pre,
             self.token_post,
+            self.subaccount_keys,
         )
     }
 
@@ -114,6 +149,7 @@ impl BalanceCollector {
             && self.native_post.len() == expected_len
             && self.token_pre.len() == expected_len
             && self.token_post.len() == expected_len
+            && self.subaccount_keys.len() == expected_len
     }
 }
 
@@ -126,14 +162,68 @@ impl BalanceCollectionRoutines for BalanceCollector {
         let (native_balances, token_balances) = self.collect_balances(account_loader, transaction);
         self.native_pre.push(native_balances);
         self.token_pre.push(token_balances);
+        // The subaccount lane is empty at the pre-balance phase (subaccounts
+        // are materialized lazily by `sol_load_subaccount` /
+        // `sol_create_subaccount` during execution). The matching tail entries
+        // are appended in `collect_subaccount_pre_balances` /
+        // `collect_post_balances` below.
+        self.subaccount_keys.push(Vec::new());
+    }
+
+    fn collect_subaccount_pre_balances<CB: TransactionProcessingCallback>(
+        &mut self,
+        account_loader: &mut AccountLoader<CB>,
+        subaccount_lane: &[KeyedAccountSharedData],
+    ) {
+        if subaccount_lane.is_empty() {
+            return;
+        }
+
+        let pre_tail = self
+            .native_pre
+            .last_mut()
+            .expect("collect_subaccount_pre_balances called without collect_pre_balances");
+        let subaccount_keys_tail = self
+            .subaccount_keys
+            .last_mut()
+            .expect("collect_subaccount_pre_balances called without collect_pre_balances");
+        for (owner_pubkey, _) in subaccount_lane.iter() {
+            // The lane is keyed by the owner-facing pubkey;
+            // `subaccount_storage_address` is the accounts-db addressing of
+            // the subaccount, which is what the loader cache and accounts-db
+            // both expose. The cache still holds pre-execution lamports here
+            // because `update_accounts_for_executed_tx` has not run yet.
+            let pre_lamports = account_loader
+                .load_account(&subaccount_storage_address(owner_pubkey))
+                .map(|account| account.lamports())
+                .unwrap_or(0);
+            pre_tail.push(pre_lamports);
+            // The recipe exposes owner-facing pubkeys verbatim — no
+            // transformation — so RPC consumers can map recipe entries back
+            // to the addresses programs see.
+            subaccount_keys_tail.push(*owner_pubkey);
+        }
     }
 
     fn collect_post_balances<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
+        subaccount_lane: &[KeyedAccountSharedData],
     ) {
-        let (native_balances, token_balances) = self.collect_balances(account_loader, transaction);
+        let (mut native_balances, token_balances) =
+            self.collect_balances(account_loader, transaction);
+
+        // F10/PRS-314: extend the per-tx native_post vector with post-execution
+        // lamports for each touched subaccount. The lane already carries
+        // post-execution state, so we read directly from it instead of going
+        // through the loader cache. Token balances stay aligned with
+        // `tx.account_keys()` only — subaccounts are program-private storage,
+        // not SPL accounts.
+        for (_, post_account) in subaccount_lane.iter() {
+            native_balances.push(post_account.lamports());
+        }
+
         self.native_post.push(native_balances);
         self.token_post.push(token_balances);
     }
@@ -150,13 +240,24 @@ impl BalanceCollectionRoutines for Option<BalanceCollector> {
         }
     }
 
+    fn collect_subaccount_pre_balances<CB: TransactionProcessingCallback>(
+        &mut self,
+        account_loader: &mut AccountLoader<CB>,
+        subaccount_lane: &[KeyedAccountSharedData],
+    ) {
+        if let Some(inner) = self {
+            inner.collect_subaccount_pre_balances(account_loader, subaccount_lane)
+        }
+    }
+
     fn collect_post_balances<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
+        subaccount_lane: &[KeyedAccountSharedData],
     ) {
         if let Some(inner) = self {
-            inner.collect_post_balances(account_loader, transaction)
+            inner.collect_post_balances(account_loader, transaction, subaccount_lane)
         }
     }
 }

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -37,6 +37,12 @@ pub struct TransactionExecutionDetails {
     /// The change in accounts data len for this transaction.
     /// NOTE: This value is valid IFF `status` is `Ok`.
     pub accounts_data_len_delta: i64,
+    /// F10/PRS-155: owner-facing keys of subaccounts accessed but left
+    /// *unchanged* this transaction (a pure `sol_read_subaccount` or a
+    /// read-only `sol_load_subaccount`). Pure receipt metadata — these are
+    /// never committed, so they don't belong on `LoadedTransaction`. The
+    /// receipt reports them by owner address only (no balances).
+    pub unchanged_subaccount_addresses: Vec<Pubkey>,
 }
 
 impl TransactionExecutionDetails {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -562,21 +562,30 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             // subaccounts the program actually touched. For
             // failed/non-executed transactions, subaccount changes are rolled
             // back, so we pass an empty slice.
-            let subaccount_lane: &[_] = match &processing_result {
-                Ok(ProcessedTransaction::Executed(executed_tx))
-                    if executed_tx.was_successful() =>
-                {
+            // F10/PRS-155: also expose the read-only (unchanged) subaccounts —
+            // owner keys only, no balances — so the receipt can list them in a
+            // separate lane. Rolled back on failed/non-executed txs, so empty
+            // there.
+            let (subaccount_lane, unchanged_subaccounts): (&[_], &[_]) = match &processing_result {
+                Ok(ProcessedTransaction::Executed(executed_tx)) if executed_tx.was_successful() => {
                     let head = tx.account_keys().len();
-                    executed_tx
-                        .loaded_transaction
-                        .accounts
-                        .get(head..)
-                        .unwrap_or(&[])
+                    (
+                        executed_tx
+                            .loaded_transaction
+                            .accounts
+                            .get(head..)
+                            .unwrap_or(&[]),
+                        &executed_tx.execution_details.unchanged_subaccount_addresses,
+                    )
                 }
-                _ => &[],
+                _ => (&[], &[]),
             };
-            let ((), collect_balances_us) = measure_us!(balance_collector
-                .collect_post_balances(&mut account_loader, tx, subaccount_lane));
+            let ((), collect_balances_us) = measure_us!(balance_collector.collect_post_balances(
+                &mut account_loader,
+                tx,
+                subaccount_lane,
+                unchanged_subaccounts,
+            ));
             execute_timings
                 .saturating_add_in_place(ExecuteTimingType::CollectBalancesUs, collect_balances_us);
 
@@ -1043,6 +1052,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let ExecutionRecord {
             accounts,
+            unchanged_subaccount_addresses,
             return_data,
             touched_account_count,
             accounts_resize_delta: accounts_data_len_delta,
@@ -1080,6 +1090,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 return_data,
                 executed_units,
                 accounts_data_len_delta,
+                // F10/PRS-155: read-only subaccounts (owner keys only) carried
+                // as receipt metadata so the balance collector can list them in
+                // the receipt's unchanged lane. Never committed.
+                unchanged_subaccount_addresses,
             },
             loaded_transaction,
             programs_modified_by_tx: program_cache_for_tx_batch.drain_modified_entries(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -521,6 +521,26 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         config,
                     );
 
+                    // F10/PRS-314: capture subaccount pre-balances **before**
+                    // `update_accounts_for_executed_tx` populates the loader
+                    // cache with post-execution state. The lane lives at
+                    // `loaded_transaction.accounts[account_keys.len()..]` and
+                    // is keyed by the owner-facing pubkey;
+                    // `subaccount_storage_address` is applied inside the
+                    // balance collector when reading pre-state from the
+                    // loader cache. Failed executions roll back subaccount
+                    // changes, so we skip the capture there.
+                    if executed_tx.was_successful() {
+                        let head = tx.account_keys().len();
+                        let lane = executed_tx
+                            .loaded_transaction
+                            .accounts
+                            .get(head..)
+                            .unwrap_or(&[]);
+                        balance_collector
+                            .collect_subaccount_pre_balances(&mut account_loader, lane);
+                    }
+
                     // Update loaded accounts cache with account states which might have changed.
                     // Also update local program cache with modifications made by the transaction,
                     // if it executed successfully.
@@ -535,8 +555,28 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             });
             execution_us = execution_us.saturating_add(single_execution_us);
 
-            let ((), collect_balances_us) =
-                measure_us!(balance_collector.collect_post_balances(&mut account_loader, tx));
+            // F10/PRS-314: the subaccount lane lives in
+            // `loaded_transaction.accounts[account_keys.len()..]` after a
+            // successful execution; we expose that slice to the balance
+            // collector so it can extend pre/post-balance vectors with the
+            // subaccounts the program actually touched. For
+            // failed/non-executed transactions, subaccount changes are rolled
+            // back, so we pass an empty slice.
+            let subaccount_lane: &[_] = match &processing_result {
+                Ok(ProcessedTransaction::Executed(executed_tx))
+                    if executed_tx.was_successful() =>
+                {
+                    let head = tx.account_keys().len();
+                    executed_tx
+                        .loaded_transaction
+                        .accounts
+                        .get(head..)
+                        .unwrap_or(&[])
+                }
+                _ => &[],
+            };
+            let ((), collect_balances_us) = measure_us!(balance_collector
+                .collect_post_balances(&mut account_loader, tx, subaccount_lane));
             execute_timings
                 .saturating_add_in_place(ExecuteTimingType::CollectBalancesUs, collect_balances_us);
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3594,8 +3594,13 @@ mod balance_collector {
                 .enable_transaction_balance_recording = true;
 
             let batch_output = env.execute();
-            let (pre_lamport_vecs, post_lamport_vecs, pre_token_vecs, post_token_vecs) =
-                batch_output.balance_collector.unwrap().into_vecs();
+            let (
+                pre_lamport_vecs,
+                post_lamport_vecs,
+                pre_token_vecs,
+                post_token_vecs,
+                _subaccount_keys,
+            ) = batch_output.balance_collector.unwrap().into_vecs();
 
             // first test the fee-payer balances
             let mut running_fee_payer_balance = STARTING_BALANCE;

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3600,6 +3600,7 @@ mod balance_collector {
                 pre_token_vecs,
                 post_token_vecs,
                 _subaccount_keys,
+                _unchanged_subaccount_keys,
             ) = batch_output.balance_collector.unwrap().into_vecs();
 
             // first test the fee-payer balances

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -129,6 +129,18 @@ declare_builtin_function!(
         invoke_context.timings.compute_subaccounts_us += compute_subaccounts_time.as_us();
 
         let subaccount_index = find_or_add_subaccount(invoke_context, subaccount_pubkey)?;
+        // F10/PRS-314: a created subaccount must always be persisted by the
+        // end-of-tx dirty filter, even a zero-lamport/zero-space allocation
+        // that no later setter mutates (`set_data_length(0)` is a no-op and
+        // with no funding transfer there is no lamport change to touch on).
+        // Touch it here so persistence is correct by construction rather than
+        // relying on a setter to remember. The load path leaves an unmodified
+        // subaccount untouched; a writable load touches it once mutated (see
+        // `commit_subaccount_slot`).
+        invoke_context
+            .transaction_context
+            .accounts()
+            .touch(subaccount_index | SUBACCOUNT_MARKER)?;
         let system_program_index = invoke_context
             .transaction_context
             .find_index_of_account(&system_program::id())

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -23,7 +23,7 @@ use {
     },
     solana_sdk_ids::system_program,
     solana_svm_log_collector::ic_msg,
-    solana_system_interface::{instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH},
+    solana_system_interface::instruction::SystemInstruction,
     solana_transaction_context::{
         create_subaccount_address, subaccount_storage_address, vm_slice::VmSlice, IndexOfAccount,
         InstructionAccount, MAX_ACCOUNTS_PER_TRANSACTION, SUBACCOUNT_MARKER,
@@ -217,16 +217,6 @@ declare_builtin_function!(
                     subaccount_pubkey,
                 );
                 return Err(InstructionError::AccountAlreadyInitialized.into());
-            }
-
-            if space > MAX_PERMITTED_DATA_LENGTH {
-                ic_msg!(
-                    invoke_context,
-                    "Allocate: requested {}, max allowed {}",
-                    space,
-                    MAX_PERMITTED_DATA_LENGTH
-                );
-                return Err(InstructionError::InvalidArgument.into());
             }
 
             subaccount.set_data_length(space as usize)?;

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -48,6 +48,34 @@ const _: () = assert!(
 
 const _: () = assert!(SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE % BPF_ALIGN_OF_U128 == 0);
 
+/// F10: shared precondition for the entire subaccount syscall surface
+/// (create / load / read / unload). Subaccount slots rely on direct-mapped
+/// account data and the stricter ABI pointer checks, so every one of these
+/// syscalls must refuse to run unless both features are active.
+///
+/// This must be the first thing each syscall does, before it mutates the
+/// `TransactionContext`, issues a system `Transfer` CPI, or persists any
+/// state — otherwise those side effects would happen under an ABI the rest of
+/// the runtime does not expect. Returns `UnsupportedSysvar` when the
+/// preconditions are not met.
+fn check_subaccount_syscall_enabled(
+    invoke_context: &mut InvokeContext,
+    syscall_name: &str,
+) -> Result<(), Error> {
+    let feature_set = invoke_context.get_feature_set();
+    let stricter_abi_and_runtime_constraints = feature_set.stricter_abi_and_runtime_constraints;
+    let account_data_direct_mapping = feature_set.account_data_direct_mapping;
+    if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
+        ic_msg!(
+            invoke_context,
+            "{}: requires stricter ABI/runtime constraints && account data direct mapping features",
+            syscall_name,
+        );
+        return Err(InstructionError::UnsupportedSysvar.into());
+    }
+    Ok(())
+}
+
 fn find_or_add_subaccount(
     invoke_context: &mut InvokeContext,
     subaccount_pubkey: Pubkey,
@@ -99,6 +127,8 @@ declare_builtin_function!(
         lamports: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        check_subaccount_syscall_enabled(invoke_context, "sol_create_subaccount")?;
+
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
         consume_compute_meter(invoke_context, syscall_base_cost)?;
         let check_aligned = invoke_context.get_check_aligned();
@@ -800,17 +830,7 @@ fn load_subaccount_impl(
     memory_mapping: &mut MemoryMapping,
     kind: AccountViewKind,
 ) -> Result<u64, Error> {
-    let stricter_abi_and_runtime_constraints = invoke_context
-        .get_feature_set()
-        .stricter_abi_and_runtime_constraints;
-    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
-    if !(stricter_abi_and_runtime_constraints && account_data_direct_mapping) {
-        ic_msg!(
-            invoke_context,
-            "sol_load_subaccount: requires stricter ABI/runtime constraints && account data direct mapping features"
-        );
-        return Err(InstructionError::UnsupportedSysvar.into());
-    }
+    check_subaccount_syscall_enabled(invoke_context, "sol_load_subaccount")?;
 
     let mut load_subaccount_time = Measure::start("load_subaccount");
     let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
@@ -1011,6 +1031,8 @@ declare_builtin_function!(
         length: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        check_subaccount_syscall_enabled(invoke_context, "sol_read_subaccount")?;
+
         // We use `load_subaccount` measure here to capture the time spent on loading subaccount
         // from the AccountsDB.
         let mut load_subaccount_time = Measure::start("load_subaccount");
@@ -1093,6 +1115,8 @@ declare_builtin_function!(
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        check_subaccount_syscall_enabled(invoke_context, "sol_unload_subaccount")?;
+
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
         consume_compute_meter(invoke_context, syscall_base_cost)?;
         let check_aligned = invoke_context.get_check_aligned();

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -274,6 +274,11 @@ impl<'ix_data> TransactionContext<'ix_data> {
 
     /// F10: register a new subaccount under the given key.
     /// Returns the subaccount index (without the `SUBACCOUNT_MARKER` high-bit).
+    ///
+    /// The entry is left **untouched**, so the end-of-tx dirty filter does not
+    /// persist it unless a caller touches it. The read-only load path relies on
+    /// this; the `sol_create_subaccount` syscall touches the entry right after
+    /// adding it so a created subaccount always persists.
     #[cfg(not(target_os = "solana"))]
     pub fn add_subaccount(
         &self,

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -1187,6 +1187,12 @@ pub struct ExecutionRecord {
     /// **owner-facing** pubkey. `subaccount_storage_address` is applied
     /// only at the accounts-db / loader-cache boundary.
     pub accounts: Vec<KeyedAccountSharedData>,
+    /// F10/PRS-155: owner-facing keys of subaccounts that were accessed but
+    /// left **unchanged** this transaction (a pure `sol_read_subaccount` or a
+    /// read-only `sol_load_subaccount`). They are deliberately absent from
+    /// `accounts` — the dirty filter does not persist them — but the receipt
+    /// reports them by owner address only (no balances).
+    pub unchanged_subaccount_addresses: Vec<Pubkey>,
     pub return_data: TransactionReturnData,
     pub touched_account_count: u64,
     pub accounts_resize_delta: i64,
@@ -1196,9 +1202,10 @@ pub struct ExecutionRecord {
 #[cfg(not(target_os = "solana"))]
 impl From<TransactionContext<'_>> for ExecutionRecord {
     fn from(context: TransactionContext) -> Self {
-        let (accounts, touched_flags, resize_delta) = Rc::try_unwrap(context.accounts)
-            .expect("transaction_context.accounts has unexpected outstanding refs")
-            .take();
+        let (accounts, unchanged_subaccount_addresses, touched_flags, resize_delta) =
+            Rc::try_unwrap(context.accounts)
+                .expect("transaction_context.accounts has unexpected outstanding refs")
+                .take();
         let touched_account_count = touched_flags
             .iter()
             .fold(0usize, |accumulator, was_touched| {
@@ -1206,6 +1213,7 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
             }) as u64;
         Self {
             accounts,
+            unchanged_subaccount_addresses,
             return_data: context.return_data,
             touched_account_count,
             accounts_resize_delta: Cell::into_inner(resize_delta),

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -1181,6 +1181,11 @@ impl BorrowedInstructionAccount<'_, '_> {
 /// Everything that needs to be recorded from a TransactionContext after execution
 #[cfg(not(target_os = "solana"))]
 pub struct ExecutionRecord {
+    /// Account values after execution. Indices `[0..main_account_count)`
+    /// correspond to the transaction's message account keys; the tail
+    /// `[main_account_count..)` is the subaccount lane, keyed by the
+    /// **owner-facing** pubkey. `subaccount_storage_address` is applied
+    /// only at the accounts-db / loader-cache boundary.
     pub accounts: Vec<KeyedAccountSharedData>,
     pub return_data: TransactionReturnData,
     pub touched_account_count: u64,

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -1352,6 +1352,52 @@ mod tests {
         );
     }
 
+    /// PRS-155: a created subaccount must persist by construction. The
+    /// `sol_create_subaccount` syscall adds the subaccount and immediately
+    /// touches it (`idx | SUBACCOUNT_MARKER`); this test exercises that lane
+    /// contract with the worst case — zero lamports, zero data, which no later
+    /// setter would touch (`set_data_length(0)` is a no-op and there is no
+    /// funding transfer) — and asserts the entry still reaches the drained
+    /// account list. Contrast with an *untouched* `add_subaccount` entry, which
+    /// the dirty filter skips (see
+    /// `test_deconstruct_persists_only_touched_subaccount`).
+    #[test]
+    fn test_touched_create_persists_zero_lamport_subaccount() {
+        let main_pubkey = Pubkey::new_from_array([1u8; 32]);
+        let main_account = AccountSharedData::new(100, 4, &Pubkey::new_unique());
+        let tx_accounts = TransactionAccounts::new(vec![(main_pubkey, main_account)]);
+
+        // Zero lamports, zero data — nothing a later setter would touch.
+        let created_pda = Pubkey::new_from_array([9u8; 32]);
+        let owner = Pubkey::new_from_array([42u8; 32]);
+        let created_index =
+            tx_accounts.add_subaccount(created_pda, AccountSharedData::new(0, 0, &owner));
+        // Mirror the create syscall: touch right after add.
+        tx_accounts
+            .touch(created_index | crate::SUBACCOUNT_MARKER)
+            .unwrap();
+
+        let (accounts, unchanged, _touched, _resize) = tx_accounts.take();
+        assert_eq!(
+            accounts.len(),
+            2,
+            "the main account and the created zero-lamport subaccount must both persist",
+        );
+        assert_eq!(accounts.first().unwrap().0, main_pubkey);
+        let (sub_key, sub_account) = accounts.get(1).unwrap();
+        assert_eq!(
+            *sub_key, created_pda,
+            "created subaccount persisted by owner key",
+        );
+        assert_eq!(sub_account.lamports(), 0);
+        assert_eq!(sub_account.data().len(), 0);
+        assert_eq!(sub_account.owner(), &owner);
+        assert!(
+            unchanged.is_empty(),
+            "a created subaccount is persisted, not reported as unchanged",
+        );
+    }
+
     /// `get_dynamic_accounts_lamports_sum` feeds the runtime balance check
     /// (`lamports_before + sum == lamports_after`). Since only touched
     /// subaccounts are persisted, the sum must exclude the lamports of an

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -2,8 +2,8 @@
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        subaccount_storage_address, vm_slice::VmSlice, IndexOfAccount,
-        MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION, MAX_ACCOUNT_DATA_LEN, SUBACCOUNT_MARKER,
+        vm_slice::VmSlice, IndexOfAccount, MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION,
+        MAX_ACCOUNT_DATA_LEN, SUBACCOUNT_MARKER,
     },
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_instruction::error::InstructionError,
@@ -707,14 +707,16 @@ impl TransactionAccounts {
                 )
             })
             .collect();
-        // F10 W10: drain the subaccount lane and append entries to the main
-        // accounts vec under the *storage* address (`hashv(&[&[1u8], pda])`).
-        // Without this, subaccount data created by `sol_create_subaccount`
-        // is silently dropped at tx commit and accounts-db never receives
-        // any state — the next transaction's `get_account_shared_data` then
-        // returns `None` and downstream programs see empty payloads.
-        // Mirrors the parasol-dev `From<TransactionContext> for ExecutionRecord`
-        // contract.
+        // F10 W10 / PRS-314: drain the subaccount lane and append entries to
+        // the main accounts vec keyed by the **owner-facing** pubkey (i.e.
+        // the address `sol_create_subaccount` / `sol_load_subaccount` returns
+        // to the program). Consumers that need accounts-db addressing —
+        // `account_saver::collect_accounts_to_store` and
+        // `AccountLoader::update_accounts_for_successful_tx` — apply
+        // `subaccount_storage_address` at the boundary themselves. Keeping
+        // owner pubkeys in the lane lets the balance collector report them
+        // verbatim in the transaction recipe without a parallel owner-keys
+        // channel.
         let sub_shared = std::mem::take(&mut *self.subaccount_shared_fields.borrow_mut());
         let sub_private = std::mem::take(&mut *self.subaccount_private_fields.borrow_mut());
         let sub_touched = std::mem::take(&mut *self.touched_subaccounts.borrow_mut());
@@ -735,9 +737,8 @@ impl TransactionAccounts {
             }
             let shared = (*shared_box).into_inner();
             let private = (*private_box).into_inner();
-            let storage_address = subaccount_storage_address(&shared.key);
             accounts.push((
-                storage_address,
+                shared.key,
                 AccountSharedData::create_from_existing_shared_data(
                     shared.lamports,
                     private.payload,
@@ -1259,10 +1260,6 @@ mod tests {
             "dynamic_accounts_lamports_sum must reflect added subaccount lamports",
         );
 
-        let derived_storage = Pubkey::new_from_array(
-            solana_sha256_hasher::hashv(&[&[1u8], subaccount_pda.as_ref()]).to_bytes(),
-        );
-
         let (accounts, _touched, _resize) = tx_accounts.take();
         assert_eq!(
             accounts.len(),
@@ -1272,10 +1269,10 @@ mod tests {
         let (main_key, _) = accounts.first().unwrap();
         assert_eq!(*main_key, main_pubkey, "main account preserved");
         let (sub_key, sub_account) = accounts.get(1).unwrap();
-        assert_eq!(
-            *sub_key, derived_storage,
-            "subaccount mapped to storage address"
-        );
+        // PRS-314: the subaccount lane carries the owner-facing pubkey;
+        // `subaccount_storage_address` is applied later at the accounts-db
+        // / loader-cache boundary.
+        assert_eq!(*sub_key, subaccount_pda, "subaccount keyed by owner pubkey");
         assert_eq!(sub_account.lamports(), 1_000);
         assert_eq!(sub_account.data(), subaccount.data());
         assert_eq!(sub_account.owner(), &owner);

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -235,8 +235,15 @@ impl WritableAccount for TransactionAccountViewMut<'_> {
 
 /// An account key and the matching account
 pub type KeyedAccountSharedData = (Pubkey, AccountSharedData);
-pub(crate) type DeconstructedTransactionAccounts =
-    (Vec<KeyedAccountSharedData>, Box<[Cell<bool>]>, Cell<i64>);
+pub(crate) type DeconstructedTransactionAccounts = (
+    Vec<KeyedAccountSharedData>,
+    // F10/PRS-155: owner-facing keys of subaccounts that were accessed but
+    // not modified this transaction (drained out of the persisted lane by the
+    // dirty filter). The receipt lists them by owner address only.
+    Vec<Pubkey>,
+    Box<[Cell<bool>]>,
+    Cell<i64>,
+);
 
 #[derive(Debug)]
 pub struct TransactionAccounts {
@@ -686,7 +693,14 @@ impl TransactionAccounts {
         self.lamports_delta.get()
     }
 
-    fn deconstruct_into_keyed_account_shared_data(&mut self) -> Vec<KeyedAccountSharedData> {
+    /// Returns the persisted accounts (main lane + the *changed* subaccount
+    /// lane, keyed by owner pubkey) together with the owner-facing keys of
+    /// subaccounts that were accessed but left unchanged this transaction.
+    /// The latter are reported in the receipt by owner address only — they are
+    /// deliberately excluded from the persisted accounts by the dirty filter.
+    fn deconstruct_into_keyed_account_shared_data(
+        &mut self,
+    ) -> (Vec<KeyedAccountSharedData>, Vec<Pubkey>) {
         let mut shared_account_fields = std::mem::take(&mut self.shared_account_fields);
         let mut private_account_fields = std::mem::take(&mut self.private_account_fields);
         let mut accounts: Vec<_> = shared_account_fields
@@ -720,9 +734,11 @@ impl TransactionAccounts {
         let sub_shared = std::mem::take(&mut *self.subaccount_shared_fields.borrow_mut());
         let sub_private = std::mem::take(&mut *self.subaccount_private_fields.borrow_mut());
         let sub_touched = std::mem::take(&mut *self.touched_subaccounts.borrow_mut());
+        let mut unchanged_subaccounts: Vec<Pubkey> = Vec::new();
         for (idx, (shared_box, private_box)) in
             sub_shared.into_iter().zip(sub_private.into_iter()).enumerate()
         {
+            let shared = (*shared_box).into_inner();
             // F10: only persist subaccounts that were actually modified this
             // transaction. `touched_subaccounts[idx]` is set by `touch()`
             // whenever a subaccount is created, funded, written, or loaded
@@ -732,10 +748,14 @@ impl TransactionAccounts {
             // identical payload (write amplification plus a write-version/slot
             // bump from a logically read-only op) and, for a subaccount that
             // never existed on-chain, resurrect an all-default tombstone.
+            //
+            // The unchanged subaccount is still surfaced to the receipt — by
+            // owner-facing key only (no balances) — so RPC consumers can see
+            // which subaccounts the transaction touched read-only.
             if !sub_touched.get(idx).copied().unwrap_or(false) {
+                unchanged_subaccounts.push(shared.key);
                 continue;
             }
-            let shared = (*shared_box).into_inner();
             let private = (*private_box).into_inner();
             accounts.push((
                 shared.key,
@@ -748,7 +768,7 @@ impl TransactionAccounts {
                 ),
             ));
         }
-        accounts
+        (accounts, unchanged_subaccounts)
     }
 
     pub(crate) fn deconstruct_into_account_shared_data(&mut self) -> Vec<AccountSharedData> {
@@ -799,8 +819,14 @@ impl TransactionAccounts {
     }
 
     pub(crate) fn take(mut self) -> DeconstructedTransactionAccounts {
-        let shared_data = self.deconstruct_into_keyed_account_shared_data();
-        (shared_data, self.touched_flags, self.resize_delta)
+        let (shared_data, unchanged_subaccounts) =
+            self.deconstruct_into_keyed_account_shared_data();
+        (
+            shared_data,
+            unchanged_subaccounts,
+            self.touched_flags,
+            self.resize_delta,
+        )
     }
 
     pub fn resize_delta(&self) -> i64 {
@@ -1260,7 +1286,7 @@ mod tests {
             "dynamic_accounts_lamports_sum must reflect added subaccount lamports",
         );
 
-        let (accounts, _touched, _resize) = tx_accounts.take();
+        let (accounts, _unchanged, _touched, _resize) = tx_accounts.take();
         assert_eq!(
             accounts.len(),
             2,
@@ -1304,20 +1330,26 @@ mod tests {
             .touch(touched_index | crate::SUBACCOUNT_MARKER)
             .unwrap();
 
-        let derived_storage = Pubkey::new_from_array(
-            solana_sha256_hasher::hashv(&[&[1u8], touched_pda.as_ref()]).to_bytes(),
-        );
-
-        let (accounts, _touched, _resize) = tx_accounts.take();
+        let (accounts, unchanged, _touched, _resize) = tx_accounts.take();
         assert_eq!(
             accounts.len(),
             2,
             "exactly the main account and the one touched subaccount must persist",
         );
         assert_eq!(accounts.first().unwrap().0, main_pubkey);
+        // PRS-155: the persisted lane carries the owner-facing pubkey;
+        // `subaccount_storage_address` is applied later at the accounts-db
+        // boundary.
         let (sub_key, sub_account) = accounts.get(1).unwrap();
-        assert_eq!(*sub_key, derived_storage, "touched subaccount persisted");
+        assert_eq!(*sub_key, touched_pda, "touched subaccount persisted by owner key");
         assert_eq!(sub_account.lamports(), 1_000);
+        // The untouched sibling is not persisted, but is reported to the
+        // receipt as an unchanged subaccount (owner key only).
+        assert_eq!(
+            unchanged,
+            vec![untouched_pda],
+            "untouched subaccount must be reported in the unchanged list, not persisted",
+        );
     }
 
     /// `get_dynamic_accounts_lamports_sum` feeds the runtime balance check

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -386,6 +386,11 @@ pub struct UiTransactionStatusMeta {
         skip_serializing_if = "OptionSerializer::should_skip"
     )]
     pub subaccount_addresses: OptionSerializer<Vec<String>>,
+    #[serde(
+        default = "OptionSerializer::skip",
+        skip_serializing_if = "OptionSerializer::should_skip"
+    )]
+    pub unchanged_subaccount_addresses: OptionSerializer<Vec<String>>,
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
@@ -395,6 +400,16 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
         } else {
             OptionSerializer::Some(
                 meta.subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        };
+        let unchanged_subaccount_addresses = if meta.unchanged_subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.unchanged_subaccount_addresses
                     .iter()
                     .map(ToString::to_string)
                     .collect(),
@@ -427,6 +442,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
             cost_units: OptionSerializer::or_skip(meta.cost_units),
             subaccount_addresses,
+            unchanged_subaccount_addresses,
         }
     }
 }
@@ -671,11 +687,15 @@ pub struct TransactionStatusMeta {
     pub return_data: Option<TransactionReturnData>,
     pub compute_units_consumed: Option<u64>,
     pub cost_units: Option<u64>,
-    /// F10/PRS-314: owner-facing pubkeys of subaccounts touched by this
+    /// F10/PRS-314: owner-facing pubkeys of subaccounts *changed* by this
     /// transaction, in the order they appear in the tail of
     /// `pre_balances`/`post_balances` (positions `[account_keys.len()..)`).
-    /// Empty for transactions that don't use subaccounts.
+    /// Empty for transactions that don't change any subaccount.
     pub subaccount_addresses: Vec<Pubkey>,
+    /// F10/PRS-155: owner-facing pubkeys of subaccounts accessed but left
+    /// *unchanged* (read-only reads/loads). Reported by address only — these
+    /// carry no entries in `pre_balances`/`post_balances`.
+    pub unchanged_subaccount_addresses: Vec<Pubkey>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -695,6 +715,7 @@ impl Default for TransactionStatusMeta {
             compute_units_consumed: None,
             cost_units: None,
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         }
     }
 }

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -26,6 +26,7 @@ use {
         v0::{LoadedAddresses, MessageAddressTableLookup},
         MessageHeader,
     },
+    solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
     solana_signature::Signature,
     solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
@@ -380,10 +381,25 @@ pub struct UiTransactionStatusMeta {
         skip_serializing_if = "OptionSerializer::should_skip"
     )]
     pub cost_units: OptionSerializer<u64>,
+    #[serde(
+        default = "OptionSerializer::skip",
+        skip_serializing_if = "OptionSerializer::should_skip"
+    )]
+    pub subaccount_addresses: OptionSerializer<Vec<String>>,
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
     fn from(meta: TransactionStatusMeta) -> Self {
+        let subaccount_addresses = if meta.subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        };
         Self {
             err: meta.status.clone().map_err(Into::into).err(),
             status: meta.status.map_err(Into::into),
@@ -410,6 +426,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             ),
             compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
             cost_units: OptionSerializer::or_skip(meta.cost_units),
+            subaccount_addresses,
         }
     }
 }
@@ -654,6 +671,11 @@ pub struct TransactionStatusMeta {
     pub return_data: Option<TransactionReturnData>,
     pub compute_units_consumed: Option<u64>,
     pub cost_units: Option<u64>,
+    /// F10/PRS-314: owner-facing pubkeys of subaccounts touched by this
+    /// transaction, in the order they appear in the tail of
+    /// `pre_balances`/`post_balances` (positions `[account_keys.len()..)`).
+    /// Empty for transactions that don't use subaccounts.
+    pub subaccount_addresses: Vec<Pubkey>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -672,6 +694,7 @@ impl Default for TransactionStatusMeta {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            subaccount_addresses: vec![],
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -194,6 +194,7 @@ fn build_simple_ui_transaction_status_meta(
         return_data: OptionSerializer::Skip,
         compute_units_consumed: OptionSerializer::Skip,
         cost_units: OptionSerializer::Skip,
+        subaccount_addresses: OptionSerializer::Skip,
     }
 }
 
@@ -233,6 +234,16 @@ fn parse_ui_transaction_status_meta(
         ),
         compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
         cost_units: OptionSerializer::or_skip(meta.cost_units),
+        subaccount_addresses: if meta.subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        },
     }
 }
 
@@ -909,6 +920,7 @@ mod test {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            subaccount_addresses: vec![],
         };
         #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -204,6 +204,16 @@ fn build_simple_ui_transaction_status_meta(
                     .collect(),
             )
         },
+        unchanged_subaccount_addresses: if meta.unchanged_subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.unchanged_subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        },
     }
 }
 
@@ -248,6 +258,16 @@ fn parse_ui_transaction_status_meta(
         } else {
             OptionSerializer::Some(
                 meta.subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        },
+        unchanged_subaccount_addresses: if meta.unchanged_subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.unchanged_subaccount_addresses
                     .iter()
                     .map(ToString::to_string)
                     .collect(),
@@ -930,6 +950,7 @@ mod test {
             compute_units_consumed: None,
             cost_units: None,
             subaccount_addresses: vec![],
+            unchanged_subaccount_addresses: vec![],
         };
         #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -194,7 +194,16 @@ fn build_simple_ui_transaction_status_meta(
         return_data: OptionSerializer::Skip,
         compute_units_consumed: OptionSerializer::Skip,
         cost_units: OptionSerializer::Skip,
-        subaccount_addresses: OptionSerializer::Skip,
+        subaccount_addresses: if meta.subaccount_addresses.is_empty() {
+            OptionSerializer::Skip
+        } else {
+            OptionSerializer::Some(
+                meta.subaccount_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            )
+        },
     }
 }
 


### PR DESCRIPTION
Add the list of loaded subaccounts to the transaction receipt:
- Updated the `execute_batch` function to include subaccount keys in the balance compilation.
- Modified the `TransactionStatusBatch` struct to store subaccount keys for transactions.
- Adjusted the `compile_collected_balances` function to return subaccount keys alongside native and token balances.
- Enhanced the `BalanceCollector` to track subaccount pre- and post-balances during transaction execution.
- Updated various modules including `transaction_balances`, `account_saver`, and `transaction_status_service` to handle subaccount addresses.
- Added serialization support for subaccount addresses in proto definitions and transaction status metadata.
- Ensured backward compatibility for older nodes by defaulting subaccount addresses to empty vectors.
- Updated tests to validate the new subaccount balance tracking functionality.