### PR TITLE
PRS-382 Reduce `syscall_base_cost` from 100 to 10

### DIFF
--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -205,7 +205,7 @@ impl SVMTransactionExecutionCost {
             cpi_bytes_per_unit: 250, // ~50MB at 200,000 units
             sysvar_base_cost: 100,
             secp256k1_recover_cost: 25_000,
-            syscall_base_cost: 100,
+            syscall_base_cost: 10,
             curve25519_edwards_validate_point_cost: 159,
             curve25519_edwards_add_cost: 473,
             curve25519_edwards_subtract_cost: 475,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2395,7 +2395,16 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(400 - 1);
+        // Each `sol_log` cost max(syscall_base_cost, string.len()). We need `ComputationalBudgetExceeded` error on last call, so
+        // we set remaining compute units to 1 less than 4 calls (one call with twice size of buffer) worth of max cost.
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+        invoke_context.mock_set_remaining(
+            syscall_base_cost.max(16)
+                + syscall_base_cost.max(16)
+                + syscall_base_cost.max(32)
+                + syscall_base_cost.max(16)
+                - 1,
+        );
         let result = SyscallLog::rust(
             &mut invoke_context,
             0x100000001, // AccessViolation

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2395,14 +2395,15 @@ mod tests {
         )
         .unwrap();
 
-        // Each `sol_log` cost max(syscall_base_cost, string.len()). We need `ComputationalBudgetExceeded` error on last call, so
-        // we set remaining compute units to 1 less than 4 calls (one call with twice size of buffer) worth of max cost.
+        // Each `sol_log` costs max(syscall_base_cost, len). We need `ComputationalBudgetExceeded` on the last call,
+        // so set remaining compute units to 1 less than the total cost of the 4 calls below.
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+        let string_len = string.len() as u64;
         invoke_context.mock_set_remaining(
-            syscall_base_cost.max(16)
-                + syscall_base_cost.max(16)
-                + syscall_base_cost.max(32)
-                + syscall_base_cost.max(16)
+            syscall_base_cost.max(string_len)
+                + syscall_base_cost.max(string_len * 2)
+                + syscall_base_cost.max(string_len)
+                + syscall_base_cost.max(string_len)
                 - 1,
         );
         let result = SyscallLog::rust(


### PR DESCRIPTION
Reduce syscall_base_cost in the Parasol environment.
While the launch is in the testing phase, we do not anticipate synchronization between nodes and replicas of old storage.

Changes:

- Lower SVMTransactionExecutionCost::syscall_base_cost default from 100 to 10.
- Update test_syscall_sol_log to compute remaining CU based on invoke_context.get_execution_cost().syscall_base_cost.
- Update solana-sdk function solana-program-log::log_cu_usage to support reduced syscall cost.