### PR TITLE
PRS-412 Restore binary compatibility with geyser-plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,11 @@ dependencies = [
  "log",
  "solana-clock",
  "solana-hash 3.1.0",
+ "solana-message",
  "solana-signature",
  "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.17",
 ]

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -19,7 +19,10 @@ agave-unstable-api = []
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
+solana-message = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
+solana-transaction-context = { workspace = true }
+solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -5,9 +5,15 @@
 use {
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
-    solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
+    solana_transaction_context::TransactionReturnData,
+    solana_transaction_error::TransactionResult,
+    solana_transaction_status::{
+        InnerInstructions, Reward, Rewards, RewardsAndNumPartitions, TransactionStatusMeta,
+        TransactionTokenBalance,
+    },
     std::{any::Any, error, io},
     thiserror::Error,
 };
@@ -120,6 +126,66 @@ pub enum ReplicaAccountInfoVersions<'a> {
     V0_0_3(&'a ReplicaAccountInfoV3<'a>),
 }
 
+/// Frozen, ABI-stable copy of `TransactionStatusMeta` exposed to Geyser plugins.
+///
+/// Geyser plugins are dynamic libraries compiled separately from the validator
+/// and receive the transaction metadata by reference across the FFI boundary.
+/// `TransactionStatusMeta` keeps evolving for ledger storage and RPC (e.g. the
+/// `subaccount_addresses` / `unchanged_subaccount_addresses` fields added by
+/// PRS-155/PRS-314), and because it is `repr(Rust)` *any* change to its fields
+/// reshuffles its memory layout. A plugin built against an older layout then
+/// reads fields at stale offsets and corrupts memory (e.g. interpreting random
+/// bytes as a `Vec` length, producing absurd allocation sizes).
+///
+/// To keep already-compiled plugins working, the `ReplicaTransactionInfo`
+/// versions below borrow this type instead of `TransactionStatusMeta`. Its
+/// field set and order MUST stay byte-for-byte identical to the
+/// `TransactionStatusMeta` layout that existed before PRS-155 (the 13 fields up
+/// to and including `cost_units`). Do NOT add, remove, reorder fields, or add
+/// `#[repr(C)]` here — any of those would break the very ABI this type freezes.
+/// New metadata must travel in a new `ReplicaTransactionInfoV4`, not here.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionStatusMetaLegacy {
+    pub status: TransactionResult<()>,
+    pub fee: u64,
+    pub pre_balances: Vec<u64>,
+    pub post_balances: Vec<u64>,
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
+    pub log_messages: Option<Vec<String>>,
+    pub pre_token_balances: Option<Vec<TransactionTokenBalance>>,
+    pub post_token_balances: Option<Vec<TransactionTokenBalance>>,
+    pub rewards: Option<Rewards>,
+    pub loaded_addresses: LoadedAddresses,
+    pub return_data: Option<TransactionReturnData>,
+    pub compute_units_consumed: Option<u64>,
+    pub cost_units: Option<u64>,
+}
+
+impl From<&TransactionStatusMeta> for TransactionStatusMetaLegacy {
+    /// Builds the frozen legacy view, dropping any fields added after the
+    /// pre-PRS-155 layout (e.g. the subaccount address lists). Clones the owned
+    /// collections because `repr(Rust)` gives no guarantee that the shared
+    /// fields keep the same offsets once `TransactionStatusMeta` gains fields,
+    /// so the bytes cannot simply be reinterpreted.
+    fn from(meta: &TransactionStatusMeta) -> Self {
+        Self {
+            status: meta.status.clone(),
+            fee: meta.fee,
+            pre_balances: meta.pre_balances.clone(),
+            post_balances: meta.post_balances.clone(),
+            inner_instructions: meta.inner_instructions.clone(),
+            log_messages: meta.log_messages.clone(),
+            pre_token_balances: meta.pre_token_balances.clone(),
+            post_token_balances: meta.post_token_balances.clone(),
+            rewards: meta.rewards.clone(),
+            loaded_addresses: meta.loaded_addresses.clone(),
+            return_data: meta.return_data.clone(),
+            compute_units_consumed: meta.compute_units_consumed,
+            cost_units: meta.cost_units,
+        }
+    }
+}
+
 /// Information about a transaction
 #[derive(Clone, Debug)]
 #[repr(C)]
@@ -134,7 +200,7 @@ pub struct ReplicaTransactionInfo<'a> {
     pub transaction: &'a SanitizedTransaction,
 
     /// Metadata of the transaction status.
-    pub transaction_status_meta: &'a TransactionStatusMeta,
+    pub transaction_status_meta: &'a TransactionStatusMetaLegacy,
 }
 
 /// Information about a transaction, including index in block
@@ -151,7 +217,7 @@ pub struct ReplicaTransactionInfoV2<'a> {
     pub transaction: &'a SanitizedTransaction,
 
     /// Metadata of the transaction status.
-    pub transaction_status_meta: &'a TransactionStatusMeta,
+    pub transaction_status_meta: &'a TransactionStatusMetaLegacy,
 
     /// The transaction's index in the block
     pub index: usize,
@@ -174,7 +240,7 @@ pub struct ReplicaTransactionInfoV3<'a> {
     pub transaction: &'a VersionedTransaction,
 
     /// Metadata of the transaction status.
-    pub transaction_status_meta: &'a TransactionStatusMeta,
+    pub transaction_status_meta: &'a TransactionStatusMetaLegacy,
 
     /// The transaction's index in the block
     pub index: usize,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -160,6 +160,8 @@ pub struct TransactionStatusMetaLegacy {
     pub compute_units_consumed: Option<u64>,
     pub cost_units: Option<u64>,
 }
+const _: () = assert!(core::mem::size_of::<TransactionStatusMetaLegacy>() == 328);
+
 
 impl From<&TransactionStatusMeta> for TransactionStatusMetaLegacy {
     /// Builds the frozen legacy view, dropping any fields added after the

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -36,6 +36,13 @@ impl TransactionNotifier for TransactionNotifierImpl {
         transaction: &VersionedTransaction,
     ) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
+
+        let plugin_manager = self.plugin_manager.read().unwrap();
+        
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
         // Hand plugins the frozen, ABI-stable view of the metadata. Plugins are
         // compiled separately and read `TransactionStatusMeta` fields by offset;
         // exposing the evolving struct directly breaks binary compatibility.
@@ -48,12 +55,6 @@ impl TransactionNotifier for TransactionNotifierImpl {
             &transaction_status_meta,
             transaction,
         );
-
-        let plugin_manager = self.plugin_manager.read().unwrap();
-
-        if plugin_manager.plugins.is_empty() {
-            return;
-        }
 
         for plugin in plugin_manager.plugins.iter() {
             if !plugin.transaction_notifications_enabled() {

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
+        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions, TransactionStatusMetaLegacy,
     },
     log::*,
     solana_clock::Slot,
@@ -36,12 +36,16 @@ impl TransactionNotifier for TransactionNotifierImpl {
         transaction: &VersionedTransaction,
     ) {
         let mut measure = Measure::start("geyser-plugin-notify_plugins_of_transaction_info");
+        // Hand plugins the frozen, ABI-stable view of the metadata. Plugins are
+        // compiled separately and read `TransactionStatusMeta` fields by offset;
+        // exposing the evolving struct directly breaks binary compatibility.
+        let transaction_status_meta = TransactionStatusMetaLegacy::from(transaction_status_meta);
         let transaction_log_info = Self::build_replica_transaction_info(
             index,
             signature,
             message_hash,
             is_vote,
-            transaction_status_meta,
+            &transaction_status_meta,
             transaction,
         );
 
@@ -94,7 +98,7 @@ impl TransactionNotifierImpl {
         signature: &'a Signature,
         message_hash: &'a Hash,
         is_vote: bool,
-        transaction_status_meta: &'a TransactionStatusMeta,
+        transaction_status_meta: &'a TransactionStatusMetaLegacy,
         transaction: &'a VersionedTransaction,
     ) -> ReplicaTransactionInfoV3<'a> {
         ReplicaTransactionInfoV3 {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2287,8 +2287,8 @@ pub struct TransactionStatusSender {
     pub dependency_tracker: Option<Arc<DependencyTracker>>,
 }
 
-#[allow(clippy::too_many_arguments)]
 impl TransactionStatusSender {
+    #[allow(clippy::too_many_arguments)]
     pub fn send_transaction_status_batch(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2287,6 +2287,7 @@ pub struct TransactionStatusSender {
     pub dependency_tracker: Option<Arc<DependencyTracker>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl TransactionStatusSender {
     pub fn send_transaction_status_batch(
         &self,


### PR DESCRIPTION
#### Problem
The `solana-test-validator` fails with a memory allocation failure when running with the geyser-plugin

#### Summary of Changes
Restore compatibility with the old geyser-plugin interface (where TransactionStatusMeta doesn't contain a list of subaccounts
