### PR TITLE
PRS-416 Add `load_subaccount_snapshot` syscall

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -2,15 +2,15 @@
 
 use {
     crate::{
-        invoke_context::{InvokeContext, SerializedAccountMetadata},
+        invoke_context::{InvokeContext, OccupiedSubaccountIndex, SerializedAccountMetadata},
         memory::{translate_slice, translate_type, translate_type_mut_for_cpi, translate_vm_slice},
         serialization::{create_memory_region_of_account, modify_memory_region_of_account},
     },
     solana_account_info::AccountInfo,
-    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
+    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_loader_v3_interface::instruction as bpf_loader_upgradeable,
     solana_program_entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    solana_pubkey::{Pubkey, PubkeyError, MAX_SEEDS},
+    solana_pubkey::{MAX_SEEDS, Pubkey, PubkeyError},
     solana_sbpf::{ebpf, memory_region::MemoryMapping},
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, native_loader},
     solana_stable_layout::stable_instruction::StableInstruction,
@@ -18,8 +18,7 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_timings::ExecuteTimings,
     solana_transaction_context::{
-        vm_slice::VmSlice, BorrowedInstructionAccount, IndexOfAccount,
-        MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN, SUBACCOUNT_MARKER,
+        BorrowedInstructionAccount, IndexOfAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN, SUBACCOUNT_MARKER, vm_slice::VmSlice
     },
     std::mem,
     thiserror::Error,
@@ -1209,7 +1208,7 @@ pub fn translate_subaccount_slots<'a>(
                     s.caller_account_metadata.as_ref(),
                     s.account_view_kind,
                 ) {
-                    (Some(idx), Some(meta), Some(kind)) => Some((
+                    (OccupiedSubaccountIndex::Subaccount(idx), Some(meta), Some(kind)) => Some((
                         s.vm_account_view_addr,
                         meta.clone(),
                         idx,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -7,10 +7,10 @@ use {
         serialization::{create_memory_region_of_account, modify_memory_region_of_account},
     },
     solana_account_info::AccountInfo,
-    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
+    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_loader_v3_interface::instruction as bpf_loader_upgradeable,
     solana_program_entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    solana_pubkey::{MAX_SEEDS, Pubkey, PubkeyError},
+    solana_pubkey::{Pubkey, PubkeyError, MAX_SEEDS},
     solana_sbpf::{ebpf, memory_region::MemoryMapping},
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, native_loader},
     solana_stable_layout::stable_instruction::StableInstruction,
@@ -18,7 +18,8 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_timings::ExecuteTimings,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN, SUBACCOUNT_MARKER, vm_slice::VmSlice
+        vm_slice::VmSlice, BorrowedInstructionAccount, IndexOfAccount,
+        MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_DATA_LEN, SUBACCOUNT_MARKER,
     },
     std::mem,
     thiserror::Error,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -264,7 +264,8 @@ pub struct SubaccountSlot {
     /// [`crate::cpi::CallerAccount::from_account_info`] and
     /// [`crate::cpi::CallerAccount::from_sol_account_info`].
     pub account_view_kind: Option<AccountViewKind>,
-    /// Specify object that is mirrored by the slot, either a subaccount or a snapshot of a subaccount.
+    /// Specify object that is mirrored by the slot, either a subaccount or 
+    /// a snapshot entry (for account or subaccount).
     pub occupied_subaccount_index: OccupiedSubaccountIndex,
     /// Writability bit recorded at `sol_load_subaccount` time. Re-install of
     /// the data region (after `sol_create_subaccount` resizes the underlying

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -197,6 +197,28 @@ pub enum AccountViewKind {
     C,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OccupiedSubaccountIndex {
+    Empty,
+    Subaccount(IndexOfAccount),
+    Snapshot(IndexOfAccount),
+}
+
+impl OccupiedSubaccountIndex {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    #[inline]
+    pub fn get_subaccount_index(&self) -> Option<IndexOfAccount> {
+        match self {
+            Self::Subaccount(idx) => Some(*idx),
+            _ => None,
+        }
+    }
+}
+
 /// Per-slot bookkeeping for a `sol_load_subaccount` reservation.
 ///
 /// At VM creation `serialize_parameters_aligned` reserves
@@ -242,9 +264,8 @@ pub struct SubaccountSlot {
     /// [`crate::cpi::CallerAccount::from_account_info`] and
     /// [`crate::cpi::CallerAccount::from_sol_account_info`].
     pub account_view_kind: Option<AccountViewKind>,
-    /// `Some(index)` once the slot is occupied, naming the subaccount index
-    /// inside `TransactionAccounts` whose state the slot mirrors.
-    pub occupied_subaccount_index: Option<IndexOfAccount>,
+    /// Specify object that is mirrored by the slot, either a subaccount or a snapshot of a subaccount.
+    pub occupied_subaccount_index: OccupiedSubaccountIndex,
     /// Writability bit recorded at `sol_load_subaccount` time. Re-install of
     /// the data region (after `sol_create_subaccount` resizes the underlying
     /// `AccountSharedData`) preserves this bit.
@@ -769,6 +790,18 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         self.environment_config
             .transaction_processing_callback
             .get_account_shared_data(pubkey)
+    }
+
+    /// Load an account as of the beginning of the current block (parent-slot
+    /// state), before any transaction in this block modified it. Used by the
+    /// read-only `sol_load_subaccount_snapshot_*` syscalls.
+    pub fn get_account_shared_data_at_block_start(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.environment_config
+            .transaction_processing_callback
+            .get_account_shared_data_at_block_start(pubkey)
     }
 
     // Should alignment be enforced during user pointer translation

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    crate::invoke_context::{SerializedAccountMetadata, SubaccountSlot},
+    crate::invoke_context::{OccupiedSubaccountIndex, SerializedAccountMetadata, SubaccountSlot},
     solana_instruction::error::InstructionError,
     solana_program_entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, NON_DUP_MARKER},
     solana_pubkey::Pubkey,
@@ -13,8 +13,7 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, TransactionContext,
-        MAX_ACCOUNTS_PER_INSTRUCTION,
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, MAX_ACCOUNTS_PER_INSTRUCTION, TransactionContext
     },
     std::mem::{self, size_of},
 };
@@ -369,7 +368,7 @@ pub fn flush_subaccount_slots(
     slots: &[SubaccountSlot],
 ) -> Result<(), InstructionError> {
     for slot in slots {
-        let Some(subaccount_index) = slot.occupied_subaccount_index else {
+        let OccupiedSubaccountIndex::Subaccount(subaccount_index) = slot.occupied_subaccount_index else {
             continue;
         };
         let header_offset = slot.buffer_position;
@@ -766,7 +765,7 @@ fn serialize_parameters_aligned(
             vm_data_addr,
             caller_account_metadata: None,
             account_view_kind: None,
-            occupied_subaccount_index: None,
+            occupied_subaccount_index: OccupiedSubaccountIndex::Empty,
             is_writable: false,
         });
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -13,7 +13,8 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
-        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, MAX_ACCOUNTS_PER_INSTRUCTION, TransactionContext
+        BorrowedInstructionAccount, IndexOfAccount, InstructionContext, TransactionContext,
+        MAX_ACCOUNTS_PER_INSTRUCTION,
     },
     std::mem::{self, size_of},
 };
@@ -368,7 +369,8 @@ pub fn flush_subaccount_slots(
     slots: &[SubaccountSlot],
 ) -> Result<(), InstructionError> {
     for slot in slots {
-        let OccupiedSubaccountIndex::Subaccount(subaccount_index) = slot.occupied_subaccount_index else {
+        let OccupiedSubaccountIndex::Subaccount(subaccount_index) = slot.occupied_subaccount_index
+        else {
             continue;
         };
         let header_offset = slot.buffer_position;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1642,7 +1642,7 @@ fn execute<'a, 'b: 'a>(
                                     .subaccount_slots
                                     .iter()
                                     .find_map(|slot| {
-                                        let subaccount_index = slot.occupied_subaccount_index?;
+                                        let subaccount_index = slot.occupied_subaccount_index.get_subaccount_index()?;
                                         let metadata = slot.caller_account_metadata.as_ref()?;
                                         let vm_end = slot
                                             .vm_data_addr

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -93,8 +93,11 @@ dependencies = [
  "log",
  "solana-clock",
  "solana-hash 3.1.0",
+ "solana-message",
  "solana-signature",
  "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
  "solana-transaction-status",
  "thiserror 2.0.17",
 ]
@@ -3773,9 +3776,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"

--- a/programs/sbf/rust/subaccount/src/lib.rs
+++ b/programs/sbf/rust/subaccount/src/lib.rs
@@ -17,6 +17,10 @@
 //!       (on a successful in-range read) verify the bytes match. Exercises
 //!       the happy path plus the missing-subaccount and out-of-range
 //!       (full/partial) edge cases — see `read_subaccount`.
+//!  10 — load_subaccount_snapshot: read-only, base-free, start-of-block load.
+//!       Takes the base pubkey from the payload (NOT from the account list, to
+//!       prove the base account is not required) and verifies the snapshot data
+//!       equals the expected bytes — see `load_snapshot_verify`.
 //!
 //! Accounts:
 //!   [0] payer / base seed (signer, writable, system-program-owned)
@@ -70,6 +74,13 @@ extern "C" {
         out_header_addr: *mut u64,
         _arg5: u64,
     ) -> u64;
+    fn sol_load_subaccount_snapshot(
+        seeds_addr: *const u8,
+        seeds_len: u64,
+        out_header_addr: *mut u64,
+        _arg4: u64,
+        _arg5: u64,
+    ) -> u64;
     fn sol_unload_subaccount(vm_header_addr: u64) -> u64;
     fn sol_read_subaccount(
         seeds_addr: *const u8,
@@ -103,6 +114,7 @@ fn process_instruction(
         7 => transfer_lamports(accounts, payload),
         8 => create_load_twice(accounts, payload),
         9 => read_subaccount(accounts, payload),
+        10 => load_snapshot_verify(payload),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }
@@ -303,6 +315,56 @@ fn read_subaccount(accounts: &[AccountInfo], payload: &[u8]) -> ProgramResult {
         return Err(ProgramError::Custom(0x92));
     }
 
+    Ok(())
+}
+
+/// Exercises `sol_load_subaccount_snapshot_rust` (disc=10).
+///
+/// Loads a read-only, start-of-block snapshot of the subaccount and verifies
+/// its data equals `expected`. The base pubkey is taken from the payload rather
+/// than from `accounts[..]`, so the caller can omit the base account from the
+/// transaction entirely — proving the snapshot load does not require it.
+///
+/// Payload layout:
+///   bytes 0..32 : base pubkey (the first seed)
+///   bytes 32..  : expected snapshot data (what the start-of-block read must
+///                 return)
+///
+/// Returns `Custom(0xA0)` on a data mismatch and `Custom(0xA1)` on a length
+/// mismatch; the slot is always released before returning.
+fn load_snapshot_verify(payload: &[u8]) -> ProgramResult {
+    let base_bytes = payload
+        .get(0..32)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let expected = payload
+        .get(32..)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds: [&[u8]; 2] = [base_bytes, SEED_TAG];
+
+    let header_addr = load_snapshot(&seeds)?;
+
+    let data_len = unsafe {
+        core::ptr::read_unaligned((header_addr + SLOT_HEADER_OFFSET_DATA_LEN) as *const u64)
+    } as usize;
+    let result = if data_len != expected.len() {
+        Err(ProgramError::Custom(0xA1))
+    } else {
+        let data_ptr = (header_addr + SLOT_HEADER_SIZE) as *const u8;
+        let data = unsafe { core::slice::from_raw_parts(data_ptr, data_len) };
+        if data == expected {
+            Ok(())
+        } else {
+            Err(ProgramError::Custom(0xA0))
+        }
+    };
+
+    // Always release the slot before returning, surfacing the verification
+    // result over a successful-unload status.
+    let u = unsafe { sol_unload_subaccount(header_addr) };
+    result?;
+    if u != SUCCESS {
+        return Err(ProgramError::from(u));
+    }
     Ok(())
 }
 
@@ -525,6 +587,23 @@ fn load_c(seeds: &[&[u8]]) -> Result<(u64, u64), ProgramError> {
         return Err(ProgramError::from(result));
     }
     Ok((header_addr, view_addr))
+}
+
+fn load_snapshot(seeds: &[&[u8]]) -> Result<u64, ProgramError> {
+    let mut header_addr: u64 = 0;
+    let result = unsafe {
+        sol_load_subaccount_snapshot(
+            seeds.as_ptr() as *const u8,
+            seeds.len() as u64,
+            &mut header_addr as *mut u64,
+            0,
+            0,
+        )
+    };
+    if result != SUCCESS {
+        return Err(ProgramError::from(result));
+    }
+    Ok(header_addr)
 }
 
 fn unload(header_addr: u64) -> ProgramResult {

--- a/programs/sbf/rust/subaccount/src/lib.rs
+++ b/programs/sbf/rust/subaccount/src/lib.rs
@@ -454,7 +454,7 @@ fn load_subaccount_snapshot_verify(payload: &[u8]) -> ProgramResult {
         if data != expected_data {
             return Err(ProgramError::Custom(0xC0));
         }
-        if snapshot_owner(header_addr) != expected_owner {
+        if snapshot_owner(header_addr).as_ref() != expected_owner {
             return Err(ProgramError::Custom(0xC2));
         }
         if snapshot_lamports(header_addr) != expected_lamports {
@@ -647,9 +647,12 @@ fn snapshot_lamports(header_addr: u64) -> u64 {
     unsafe { core::ptr::read_unaligned((header_addr + SLOT_HEADER_OFFSET_LAMPORTS) as *const u64) }
 }
 
-/// Borrows the 32-byte `owner` field out of a slot header.
-fn snapshot_owner(header_addr: u64) -> &'static [u8] {
-    unsafe { core::slice::from_raw_parts((header_addr + SLOT_HEADER_OFFSET_OWNER) as *const u8, 32) }
+/// Reads the 32-byte `owner` field out of a slot header.
+fn snapshot_owner(header_addr: u64) -> Pubkey {
+    let bytes = unsafe {
+        core::ptr::read_unaligned((header_addr + SLOT_HEADER_OFFSET_OWNER) as *const [u8; 32])
+    };
+    Pubkey::new_from_array(bytes)
 }
 
 /// Verifies the snapshot's `data_len` and data bytes equal `expected`.
@@ -701,7 +704,7 @@ fn load_account_snapshot_verify(payload: &[u8]) -> ProgramResult {
         if data != expected_data {
             return Err(ProgramError::Custom(0xB0));
         }
-        if snapshot_owner(header_addr) != expected_owner {
+        if snapshot_owner(header_addr).as_ref() != expected_owner {
             return Err(ProgramError::Custom(0xB2));
         }
         if snapshot_lamports(header_addr) != expected_lamports {

--- a/programs/sbf/rust/subaccount/src/lib.rs
+++ b/programs/sbf/rust/subaccount/src/lib.rs
@@ -21,6 +21,38 @@
 //!       Takes the base pubkey from the payload (NOT from the account list, to
 //!       prove the base account is not required) and verifies the snapshot data
 //!       equals the expected bytes — see `load_snapshot_verify`.
+//!  11 — load_subaccount_snapshot + verify owner / lamports / data_len / data
+//!       against expected values from the payload — see
+//!       `load_subaccount_snapshot_verify`.
+//!  12 — load_subaccount_snapshot + attempt to write into the read-only data
+//!       region (must fault) — see `load_subaccount_snapshot_cannot_modify`.
+//!  13 — load_subaccount_snapshot twice for the same subaccount in one
+//!       instruction; the second load must fail — see
+//!       `load_subaccount_snapshot_twice`.
+//!  14 — load_subaccount_snapshot + unload + reload + unload, proving a freed
+//!       snapshot slot can be reused — see `load_subaccount_snapshot_unload_reload`.
+//!  15 — load two distinct subaccount snapshots into two slots concurrently and
+//!       verify each — see `load_two_subaccount_snapshots`.
+//!  16 — writable load + overwrite, then load a snapshot of the SAME subaccount
+//!       and verify it still reads the start-of-block value, proving the
+//!       snapshot lane is independent of the live subaccount lane within a
+//!       single instruction — see `subaccount_snapshot_independent_from_writable_load`.
+//!  17 — load_account_snapshot: read-only, base-free, start-of-block load of an
+//!       arbitrary account *by pubkey* (not seeds). Verifies the snapshot's
+//!       owner / lamports / data_len / data against expected values from the
+//!       payload — see `load_account_snapshot_verify`.
+//!  18 — load_account_snapshot + attempt to write into the read-only data
+//!       region (must fault) — see `load_account_snapshot_cannot_modify`.
+//!  19 — load_account_snapshot twice for the same pubkey in one instruction;
+//!       the second load must fail — see `load_account_snapshot_twice`.
+//!  20 — load_account_snapshot + unload + reload + unload, proving a freed
+//!       snapshot slot can be reused — see `load_account_snapshot_unload_reload`.
+//!  21 — load two distinct account snapshots into two slots concurrently and
+//!       verify each — see `load_two_account_snapshots`.
+//!  22 — load a subaccount snapshot (by seeds) AND an account snapshot (by
+//!       pubkey) in one instruction, proving the `Account` and `Subaccount`
+//!       snapshot-key variants never collide — see
+//!       `account_and_subaccount_snapshot_distinct`.
 //!
 //! Accounts:
 //!   [0] payer / base seed (signer, writable, system-program-owned)
@@ -81,6 +113,13 @@ extern "C" {
         _arg4: u64,
         _arg5: u64,
     ) -> u64;
+    fn sol_load_account_snapshot(
+        pubkey_addr: *const u8,
+        out_header_addr: *mut u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+    ) -> u64;
     fn sol_unload_subaccount(vm_header_addr: u64) -> u64;
     fn sol_read_subaccount(
         seeds_addr: *const u8,
@@ -115,6 +154,18 @@ fn process_instruction(
         8 => create_load_twice(accounts, payload),
         9 => read_subaccount(accounts, payload),
         10 => load_snapshot_verify(payload),
+        11 => load_subaccount_snapshot_verify(payload),
+        12 => load_subaccount_snapshot_cannot_modify(payload),
+        13 => load_subaccount_snapshot_twice(payload),
+        14 => load_subaccount_snapshot_unload_reload(payload),
+        15 => load_two_subaccount_snapshots(payload),
+        16 => subaccount_snapshot_independent_from_writable_load(accounts, payload),
+        17 => load_account_snapshot_verify(payload),
+        18 => load_account_snapshot_cannot_modify(payload),
+        19 => load_account_snapshot_twice(payload),
+        20 => load_account_snapshot_unload_reload(payload),
+        21 => load_two_account_snapshots(payload),
+        22 => account_and_subaccount_snapshot_distinct(payload),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }
@@ -364,6 +415,453 @@ fn load_snapshot_verify(payload: &[u8]) -> ProgramResult {
     result?;
     if u != SUCCESS {
         return Err(ProgramError::from(u));
+    }
+    Ok(())
+}
+
+/// Exercises `sol_load_subaccount_snapshot` with full metadata verification
+/// (disc=11). Base pubkey is taken from the payload (base-free).
+///
+/// Payload layout:
+///   bytes  0..32 : base pubkey (first seed)
+///   bytes 32..64 : expected owner
+///   bytes 64..72 : expected lamports (u64 LE)
+///   bytes 72..   : expected snapshot data
+///
+/// Custom codes: 0xC0 data mismatch, 0xC1 data_len mismatch, 0xC2 owner
+/// mismatch, 0xC3 lamports mismatch.
+fn load_subaccount_snapshot_verify(payload: &[u8]) -> ProgramResult {
+    let base = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected_owner = payload.get(32..64).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected_lamports = u64::from_le_bytes(
+        payload
+            .get(64..72)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    );
+    let expected_data = payload.get(72..).ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds: [&[u8]; 2] = [base, SEED_TAG];
+
+    let header_addr = load_snapshot(&seeds)?;
+
+    let result: ProgramResult = (|| {
+        let data_len = snapshot_data_len(header_addr);
+        if data_len != expected_data.len() {
+            return Err(ProgramError::Custom(0xC1));
+        }
+        let data =
+            unsafe { core::slice::from_raw_parts((header_addr + SLOT_HEADER_SIZE) as *const u8, data_len) };
+        if data != expected_data {
+            return Err(ProgramError::Custom(0xC0));
+        }
+        if snapshot_owner(header_addr) != expected_owner {
+            return Err(ProgramError::Custom(0xC2));
+        }
+        if snapshot_lamports(header_addr) != expected_lamports {
+            return Err(ProgramError::Custom(0xC3));
+        }
+        Ok(())
+    })();
+
+    let u = unsafe { sol_unload_subaccount(header_addr) };
+    result?;
+    if u != SUCCESS {
+        return Err(ProgramError::from(u));
+    }
+    Ok(())
+}
+
+/// Read-only enforcement for a subaccount snapshot (disc=12). Loads the
+/// snapshot then stores into its data region; the region is read-only so the
+/// store must fault and abort the instruction. `Custom(0xC5)` is returned only
+/// if the write was wrongly accepted.
+fn load_subaccount_snapshot_cannot_modify(payload: &[u8]) -> ProgramResult {
+    let base = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds: [&[u8]; 2] = [base, SEED_TAG];
+    let header_addr = load_snapshot(&seeds)?;
+    let data_ptr = (header_addr + SLOT_HEADER_SIZE) as *mut u8;
+    unsafe { core::ptr::write_unaligned(data_ptr, 0xFF) };
+    let _ = unsafe { sol_unload_subaccount(header_addr) };
+    Err(ProgramError::Custom(0xC5))
+}
+
+/// Loading the same subaccount snapshot twice in one instruction must fail
+/// (disc=13). Returns `Custom(0xC6)` if the second load unexpectedly succeeds;
+/// otherwise propagates the syscall error.
+fn load_subaccount_snapshot_twice(payload: &[u8]) -> ProgramResult {
+    let base = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds: [&[u8]; 2] = [base, SEED_TAG];
+    let _h1 = load_snapshot(&seeds)?;
+    let mut header2: u64 = 0;
+    let r2 = unsafe {
+        sol_load_subaccount_snapshot(
+            seeds.as_ptr() as *const u8,
+            seeds.len() as u64,
+            &mut header2 as *mut u64,
+            0,
+            0,
+        )
+    };
+    if r2 == SUCCESS {
+        return Err(ProgramError::Custom(0xC6));
+    }
+    Err(ProgramError::from(r2))
+}
+
+/// Load a subaccount snapshot, verify + unload, then reload the SAME subaccount
+/// into a freed slot and verify again (disc=14). Proves slot reuse.
+///
+/// Payload layout: base(32) ++ expected data.
+fn load_subaccount_snapshot_unload_reload(payload: &[u8]) -> ProgramResult {
+    let base = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected = payload.get(32..).ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds: [&[u8]; 2] = [base, SEED_TAG];
+
+    let h1 = load_snapshot(&seeds)?;
+    verify_snapshot_data(h1, expected)?;
+    unload(h1)?;
+
+    let h2 = load_snapshot(&seeds)?;
+    verify_snapshot_data(h2, expected)?;
+    unload(h2)
+}
+
+/// Load two distinct subaccount snapshots into two slots at once and verify
+/// each (disc=15). Both slots are released before returning.
+///
+/// Payload layout:
+///   bytes  0..32 : base #1
+///   bytes 32..64 : base #2
+///   bytes 64..66 : data #1 length (u16 LE)
+///   bytes 66..66+len1        : expected data #1
+///   bytes 66+len1..          : expected data #2
+fn load_two_subaccount_snapshots(payload: &[u8]) -> ProgramResult {
+    let base1 = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let base2 = payload.get(32..64).ok_or(ProgramError::InvalidInstructionData)?;
+    let len1 = u16::from_le_bytes(
+        payload
+            .get(64..66)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    ) as usize;
+    let data1 = payload
+        .get(66..66 + len1)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let data2 = payload
+        .get(66 + len1..)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+    let seeds1: [&[u8]; 2] = [base1, SEED_TAG];
+    let seeds2: [&[u8]; 2] = [base2, SEED_TAG];
+    let h1 = load_snapshot(&seeds1)?;
+    let h2 = load_snapshot(&seeds2)?;
+
+    let result: ProgramResult = (|| {
+        verify_snapshot_data(h1, data1)?;
+        verify_snapshot_data(h2, data2)?;
+        Ok(())
+    })();
+
+    let u2 = unsafe { sol_unload_subaccount(h2) };
+    let u1 = unsafe { sol_unload_subaccount(h1) };
+    result?;
+    if u1 != SUCCESS {
+        return Err(ProgramError::from(u1));
+    }
+    if u2 != SUCCESS {
+        return Err(ProgramError::from(u2));
+    }
+    Ok(())
+}
+
+/// Proves the snapshot lane is independent of the live subaccount lane within a
+/// single instruction (disc=16). `accounts[0]` is the base (writable). Loads
+/// the subaccount writable, overwrites its data with V2, then loads a snapshot
+/// of the SAME subaccount and asserts it still reads the start-of-block value
+/// V1. Finally commits V2 (unload of the writable slot).
+///
+/// Payload layout:
+///   bytes 0..2 : V1 length (u16 LE)
+///   bytes 2..2+len : expected start-of-block data V1
+///   bytes 2+len..  : V2 to overwrite the live subaccount with
+fn subaccount_snapshot_independent_from_writable_load(
+    accounts: &[AccountInfo],
+    payload: &[u8],
+) -> ProgramResult {
+    let base = accounts.get(0).ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let len1 = u16::from_le_bytes(
+        payload
+            .get(0..2)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    ) as usize;
+    let v1 = payload
+        .get(2..2 + len1)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let v2 = payload
+        .get(2 + len1..)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let seeds = seeds_from_payer(base.key);
+
+    // Writable load + overwrite the live subaccount with V2 (subaccount lane).
+    let (header_w, _view) = load_rust(&seeds)?;
+    write_data(header_w, v2);
+
+    // Snapshot load — must still observe the start-of-block value V1.
+    let header_s = load_snapshot(&seeds)?;
+    let result = verify_snapshot_data(header_s, v1);
+    let us = unsafe { sol_unload_subaccount(header_s) };
+
+    // Commit the writable overwrite.
+    let uw = unload(header_w);
+
+    result?;
+    if us != SUCCESS {
+        return Err(ProgramError::from(us));
+    }
+    uw
+}
+
+/// Loads a read-only, start-of-block snapshot of an arbitrary account by its
+/// pubkey via `sol_load_account_snapshot` and returns the slot header address.
+fn load_account_snapshot(pubkey: &[u8]) -> Result<u64, ProgramError> {
+    let mut header_addr: u64 = 0;
+    let result = unsafe {
+        sol_load_account_snapshot(pubkey.as_ptr(), &mut header_addr as *mut u64, 0, 0, 0)
+    };
+    if result != SUCCESS {
+        return Err(ProgramError::from(result));
+    }
+    Ok(header_addr)
+}
+
+/// Reads the `data_len` field out of a slot header.
+fn snapshot_data_len(header_addr: u64) -> usize {
+    let len =
+        unsafe { core::ptr::read_unaligned((header_addr + SLOT_HEADER_OFFSET_DATA_LEN) as *const u64) };
+    len as usize
+}
+
+/// Reads the `lamports` field out of a slot header.
+fn snapshot_lamports(header_addr: u64) -> u64 {
+    unsafe { core::ptr::read_unaligned((header_addr + SLOT_HEADER_OFFSET_LAMPORTS) as *const u64) }
+}
+
+/// Borrows the 32-byte `owner` field out of a slot header.
+fn snapshot_owner(header_addr: u64) -> &'static [u8] {
+    unsafe { core::slice::from_raw_parts((header_addr + SLOT_HEADER_OFFSET_OWNER) as *const u8, 32) }
+}
+
+/// Verifies the snapshot's `data_len` and data bytes equal `expected`.
+/// Returns `Custom(0xA1)` on a length mismatch and `Custom(0xA0)` on a byte
+/// mismatch (same codes `load_snapshot_verify` uses).
+fn verify_snapshot_data(header_addr: u64, expected: &[u8]) -> ProgramResult {
+    let data_len = snapshot_data_len(header_addr);
+    if data_len != expected.len() {
+        return Err(ProgramError::Custom(0xA1));
+    }
+    let data = unsafe { core::slice::from_raw_parts((header_addr + SLOT_HEADER_SIZE) as *const u8, data_len) };
+    if data != expected {
+        return Err(ProgramError::Custom(0xA0));
+    }
+    Ok(())
+}
+
+/// Exercises `sol_load_account_snapshot` (disc=11).
+///
+/// Payload layout:
+///   bytes  0..32 : account pubkey
+///   bytes 32..64 : expected owner
+///   bytes 64..72 : expected lamports (u64 LE)
+///   bytes 72..   : expected snapshot data
+///
+/// Verifies the start-of-block owner / lamports / data_len / data, then
+/// releases the slot. Custom codes: 0xB0 data mismatch, 0xB1 data_len
+/// mismatch, 0xB2 owner mismatch, 0xB3 lamports mismatch.
+fn load_account_snapshot_verify(payload: &[u8]) -> ProgramResult {
+    let pubkey = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected_owner = payload.get(32..64).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected_lamports = u64::from_le_bytes(
+        payload
+            .get(64..72)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    );
+    let expected_data = payload.get(72..).ok_or(ProgramError::InvalidInstructionData)?;
+
+    let header_addr = load_account_snapshot(pubkey)?;
+
+    let result: ProgramResult = (|| {
+        let data_len = snapshot_data_len(header_addr);
+        if data_len != expected_data.len() {
+            return Err(ProgramError::Custom(0xB1));
+        }
+        let data =
+            unsafe { core::slice::from_raw_parts((header_addr + SLOT_HEADER_SIZE) as *const u8, data_len) };
+        if data != expected_data {
+            return Err(ProgramError::Custom(0xB0));
+        }
+        if snapshot_owner(header_addr) != expected_owner {
+            return Err(ProgramError::Custom(0xB2));
+        }
+        if snapshot_lamports(header_addr) != expected_lamports {
+            return Err(ProgramError::Custom(0xB3));
+        }
+        Ok(())
+    })();
+
+    // Always release the slot before surfacing the verification result.
+    let u = unsafe { sol_unload_subaccount(header_addr) };
+    result?;
+    if u != SUCCESS {
+        return Err(ProgramError::from(u));
+    }
+    Ok(())
+}
+
+/// Exercises read-only enforcement of an account snapshot (disc=12).
+///
+/// Loads the snapshot then attempts to store into its data region. The region
+/// is mapped read-only, so the store must fault and abort the instruction in
+/// the VM — control never returns. If it somehow returns, the write was
+/// wrongly accepted: release the slot and report `Custom(0xB5)`.
+fn load_account_snapshot_cannot_modify(payload: &[u8]) -> ProgramResult {
+    let pubkey = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let header_addr = load_account_snapshot(pubkey)?;
+    let data_ptr = (header_addr + SLOT_HEADER_SIZE) as *mut u8;
+    unsafe { core::ptr::write_unaligned(data_ptr, 0xFF) };
+    // Unreachable on a correctly read-only mapping.
+    let _ = unsafe { sol_unload_subaccount(header_addr) };
+    Err(ProgramError::Custom(0xB5))
+}
+
+/// Loading the same account snapshot twice in one instruction must fail
+/// (disc=13). Returns `Custom(0xB6)` if the second load unexpectedly succeeds;
+/// otherwise propagates the syscall error so the test can assert on it.
+fn load_account_snapshot_twice(payload: &[u8]) -> ProgramResult {
+    let pubkey = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let _h1 = load_account_snapshot(pubkey)?;
+    let mut header2: u64 = 0;
+    let r2 = unsafe {
+        sol_load_account_snapshot(pubkey.as_ptr(), &mut header2 as *mut u64, 0, 0, 0)
+    };
+    if r2 == SUCCESS {
+        return Err(ProgramError::Custom(0xB6));
+    }
+    Err(ProgramError::from(r2))
+}
+
+/// Loads an account snapshot, verifies + unloads it, then reloads the SAME
+/// account into a (now-freed) slot and verifies again (disc=14). Proves a
+/// released snapshot slot can be reused.
+///
+/// Payload layout: pubkey(32) ++ expected data.
+fn load_account_snapshot_unload_reload(payload: &[u8]) -> ProgramResult {
+    let pubkey = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let expected = payload.get(32..).ok_or(ProgramError::InvalidInstructionData)?;
+
+    let h1 = load_account_snapshot(pubkey)?;
+    verify_snapshot_data(h1, expected)?;
+    unload(h1)?;
+
+    let h2 = load_account_snapshot(pubkey)?;
+    verify_snapshot_data(h2, expected)?;
+    unload(h2)
+}
+
+/// Loads two distinct account snapshots into two slots at once and verifies
+/// each (disc=15). Both slots are released before returning.
+///
+/// Payload layout:
+///   bytes  0..32 : pubkey #1
+///   bytes 32..64 : pubkey #2
+///   bytes 64..66 : data #1 length (u16 LE)
+///   bytes 66..66+len1        : expected data #1
+///   bytes 66+len1..          : expected data #2
+fn load_two_account_snapshots(payload: &[u8]) -> ProgramResult {
+    let pk1 = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let pk2 = payload.get(32..64).ok_or(ProgramError::InvalidInstructionData)?;
+    let len1 = u16::from_le_bytes(
+        payload
+            .get(64..66)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    ) as usize;
+    let data1 = payload
+        .get(66..66 + len1)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let data2 = payload
+        .get(66 + len1..)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+    let h1 = load_account_snapshot(pk1)?;
+    let h2 = load_account_snapshot(pk2)?;
+
+    let result: ProgramResult = (|| {
+        verify_snapshot_data(h1, data1)?;
+        verify_snapshot_data(h2, data2)?;
+        Ok(())
+    })();
+
+    // Release both slots regardless of the verification outcome.
+    let u2 = unsafe { sol_unload_subaccount(h2) };
+    let u1 = unsafe { sol_unload_subaccount(h1) };
+    result?;
+    if u1 != SUCCESS {
+        return Err(ProgramError::from(u1));
+    }
+    if u2 != SUCCESS {
+        return Err(ProgramError::from(u2));
+    }
+    Ok(())
+}
+
+/// Loads a subaccount snapshot (by seeds) and an account snapshot (by pubkey)
+/// in one instruction (disc=16). The two use distinct `SnapshotKey` variants —
+/// `Subaccount(derived)` vs `Account(pubkey)` — so even when the test points
+/// the account snapshot at the subaccount's *derived* address they must resolve
+/// to independent lane entries with their own data.
+///
+/// Payload layout:
+///   bytes  0..32 : base pubkey (first subaccount seed)
+///   bytes 32..64 : account pubkey for the account snapshot
+///   bytes 64..66 : account data length (u16 LE)
+///   bytes 66..66+len : expected account-snapshot data
+///   bytes 66+len..   : expected subaccount-snapshot data
+fn account_and_subaccount_snapshot_distinct(payload: &[u8]) -> ProgramResult {
+    let base = payload.get(0..32).ok_or(ProgramError::InvalidInstructionData)?;
+    let account_pk = payload.get(32..64).ok_or(ProgramError::InvalidInstructionData)?;
+    let acct_len = u16::from_le_bytes(
+        payload
+            .get(64..66)
+            .and_then(|s| s.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?,
+    ) as usize;
+    let account_data = payload
+        .get(66..66 + acct_len)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let subaccount_data = payload
+        .get(66 + acct_len..)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+    let seeds: [&[u8]; 2] = [base, SEED_TAG];
+    let h_sub = load_snapshot(&seeds)?;
+    let h_acct = load_account_snapshot(account_pk)?;
+
+    let result: ProgramResult = (|| {
+        verify_snapshot_data(h_sub, subaccount_data)?;
+        verify_snapshot_data(h_acct, account_data)?;
+        Ok(())
+    })();
+
+    let ua = unsafe { sol_unload_subaccount(h_acct) };
+    let us = unsafe { sol_unload_subaccount(h_sub) };
+    result?;
+    if us != SUCCESS {
+        return Err(ProgramError::from(us));
+    }
+    if ua != SUCCESS {
+        return Err(ProgramError::from(ua));
     }
     Ok(())
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -6559,6 +6559,115 @@ fn test_program_sbf_subaccount_snapshot_tracks_parent_not_origin() {
     );
 }
 
+/// (9) HIGH-1 determinism core, subaccount lane: the full
+/// write-in-tx-A / snapshot-in-a-later-tx-of-the-same-block / next-block
+/// scenario, asserting owner + lamports + data in one test.
+///
+/// The snapshot syscalls read the *parent slot* via
+/// `get_account_shared_data_at_block_start` →
+/// `Bank::proper_ancestors()` (the current slot excluded). That read must be
+/// byte-identical on the leader and on every replaying validator, so a snapshot
+/// taken in block N must observe X exactly as of the block boundary regardless
+/// of what earlier transactions in block N did to it.
+///
+/// Timeline:
+///   * Block A     — create subaccount X with V1 (owner = program_id,
+///                   lamports = funding). This is X's pre-block (parent-slot)
+///                   state for block N.
+///   * Block N tx A — a real transaction overwrites X's data to V2.
+///   * Block N tx B — `load_subaccount_snapshot(X)` must report owner/lamports
+///                   == X's pre-block values and data == V1 (NOT A's V2).
+///   * Block N+1    — `load_subaccount_snapshot(X)` must now report data == V2,
+///                   because block N (with A's write committed) is its parent.
+///
+/// Discriminating power: had the snapshot delegated to plain
+/// `get_account_shared_data` (which includes the current slot's writes), tx B
+/// would observe A's V2 and the disc=11 verifier would fail with `Custom(0xC0)`
+/// (data mismatch). It passes only because the parent-slot read excludes block
+/// N. The block-N+1 read then proves the parent read is not merely a frozen
+/// creation-time value — it tracks the committed parent slot.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_isolation_full() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"high1-subaccount-pre-block-val1"; // 31 bytes
+    let v2: &[u8] = b"high1-subaccount-txA-overwrite2"; // 31 bytes, same len
+    assert_eq!(v1.len(), v2.len());
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create X with V1 (owner = program_id, lamports = funding).
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block N so the V1 write lives in the parent slot.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N");
+
+    // Block N, tx A — a real transaction overwrites X's data to V2.
+    let ix_tx_a = subaccount_instruction(program_id, base_pubkey, true, 1, v2, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_tx_a);
+    assert!(
+        status.is_ok(),
+        "tx A overwrite failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Sanity: the live mid-block state is now V2.
+    let storage_addr = subaccount_storage_addr_for(&base_pubkey, &program_id);
+    assert_eq!(
+        bank.get_account(&storage_addr)
+            .expect("subaccount exists")
+            .data(),
+        v2,
+        "tx A's overwrite should be the live state",
+    );
+
+    // Block N, tx B — the snapshot must report X's pre-block owner / lamports /
+    // data (V1), NOT A's mid-block V2. Fails with Custom(0xC0) if the read
+    // leaked A's write (i.e. if it used get_account_shared_data).
+    let ix_tx_b = subaccount_snapshot_verify_instruction(
+        program_id,
+        &base_pubkey,
+        &program_id,
+        SUBACCOUNT_FUNDING_LAMPORTS,
+        v1,
+    );
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_tx_b);
+    assert!(
+        status.is_ok(),
+        "same-block snapshot must read pre-block V1, not tx A's V2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block N+1 — block N (with A's write) is now the parent, so the
+    // snapshot must observe A's committed V2.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N+1");
+    let ix_tx_c = subaccount_snapshot_verify_instruction(
+        program_id,
+        &base_pubkey,
+        &program_id,
+        SUBACCOUNT_FUNDING_LAMPORTS,
+        v2,
+    );
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_tx_c);
+    assert!(
+        status.is_ok(),
+        "next-block snapshot must read tx A's committed V2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
 // ============================================================================
 // `sol_load_account_snapshot` — read-only, base-free, start-of-block load of an
 // arbitrary account *by pubkey* (not subaccount seeds). Mirrors the subaccount
@@ -6661,6 +6770,88 @@ fn test_program_sbf_account_snapshot_ignores_midblock_write() {
     assert!(
         status.is_ok(),
         "snapshot must read start-of-block V1, not mid-block V2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// HIGH-1 determinism core, account lane: the full
+/// write-in-tx-A / snapshot-in-a-later-tx-of-the-same-block / next-block
+/// scenario, asserting owner + lamports + data in one test. Mirrors
+/// `test_program_sbf_subaccount_snapshot_isolation_full` but drives the
+/// `SnapshotKey::Account` lane, and uses a genuine `system_program::Transfer`
+/// transaction (not a direct `store_account`) as the in-block writer tx A.
+///
+/// Timeline:
+///   * Block A      — store X (system-owned, lamports = L1). X's pre-block state.
+///   * Block N tx A — a real system Transfer credits X to L1 + DELTA = L2.
+///   * Block N tx B — `load_account_snapshot(X)` must report lamports == L1 and
+///                    owner/data == X's pre-block values (NOT L2).
+///   * Block N+1    — `load_account_snapshot(X)` must now report lamports == L2.
+///
+/// Discriminating power: a plain `get_account_shared_data` read (current slot
+/// included) would see tx A's L2 in block N and the disc=17 verifier would fail
+/// with `Custom(0xB3)` (lamports mismatch). It passes only because the
+/// parent-slot read excludes block N; the block-N+1 read then proves the read
+/// tracks the committed parent slot rather than a frozen value.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_isolation_full() {
+    use solana_system_interface::instruction as system_instruction;
+
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = system_program::id(); // system-owned so a Transfer can credit it
+    let l1: u64 = 5_000_000; // pre-block balance (rent-exempt for 0-byte data)
+    let delta: u64 = 1_500_000;
+    let l2: u64 = l1 + delta;
+
+    // Block A — store X (system-owned, empty data, lamports = L1).
+    bank.store_account(&account_pk, &make_account(l1, &owner, &[]));
+
+    // Advance to block N so the L1 write lives in the parent slot.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N");
+
+    // Block N, tx A — a real Transfer credits X from the mint, raising it to L2.
+    let transfer_ix = system_instruction::transfer(&mint_keypair.pubkey(), &account_pk, delta);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, transfer_ix);
+    assert!(
+        status.is_ok(),
+        "tx A transfer failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Sanity: the live mid-block balance is now L2.
+    assert_eq!(
+        bank.get_account(&account_pk).expect("account exists").lamports(),
+        l2,
+        "tx A's transfer should be the live state",
+    );
+
+    // Block N, tx B — the snapshot must report X's pre-block lamports (L1),
+    // owner and (empty) data, NOT tx A's mid-block L2. Fails with Custom(0xB3)
+    // if the read leaked A's write.
+    let ix_tx_b = account_snapshot_verify_instruction(program_id, &account_pk, &owner, l1, &[]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_tx_b);
+    assert!(
+        status.is_ok(),
+        "same-block snapshot must read pre-block L1, not tx A's L2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block N+1 — block N (with A's transfer committed) is now the
+    // parent, so the snapshot must observe L2.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N+1");
+    let ix_tx_c = account_snapshot_verify_instruction(program_id, &account_pk, &owner, l2, &[]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_tx_c);
+    assert!(
+        status.is_ok(),
+        "next-block snapshot must read tx A's committed L2: {status:?}\nlogs:\n{}",
         logs.join("\n")
     );
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -6182,6 +6182,724 @@ fn test_program_sbf_subaccount_snapshot_ignores_midblock_write() {
     );
 }
 
+// ============================================================================
+// `sol_load_subaccount_snapshot` — extended coverage (metadata, missing,
+// read-only, double-load, slot reuse, two-at-once, and lane independence from a
+// concurrent writable load / across blocks).
+// ============================================================================
+
+/// Build a disc=11 `load_subaccount_snapshot_verify` instruction: read the
+/// start-of-block snapshot derived from `base` and assert owner / lamports /
+/// data_len / data match. No account metas — proves the read is base-free.
+#[cfg(feature = "sbf_rust")]
+fn subaccount_snapshot_verify_instruction(
+    program_id: Pubkey,
+    base: &Pubkey,
+    expected_owner: &Pubkey,
+    expected_lamports: u64,
+    expected_data: &[u8],
+) -> Instruction {
+    let mut data = vec![11u8];
+    data.extend_from_slice(base.as_ref());
+    data.extend_from_slice(expected_owner.as_ref());
+    data.extend_from_slice(&expected_lamports.to_le_bytes());
+    data.extend_from_slice(expected_data);
+    Instruction::new_with_bytes(program_id, &data, vec![])
+}
+
+/// (1) The snapshot of a created subaccount reports the correct owner
+/// (== program_id), lamports (== funding) and data_len — not just the bytes.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_verifies_metadata() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"subaccount-snapshot-metadata-v1"; // 31 bytes
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create the subaccount (owner=program_id, lamports=funding).
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    let ix = subaccount_snapshot_verify_instruction(
+        program_id,
+        &base_pubkey,
+        &program_id,
+        SUBACCOUNT_FUNDING_LAMPORTS,
+        v1,
+    );
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "subaccount snapshot metadata mismatch: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// (2) A snapshot of a subaccount that was never created reads as the empty
+/// default (zero owner / zero lamports / empty data) rather than erroring.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_missing_is_empty() {
+    let (_bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let base_pubkey = Pubkey::new_unique();
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    let ix =
+        subaccount_snapshot_verify_instruction(program_id, &base_pubkey, &Pubkey::default(), 0, &[]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "missing-subaccount snapshot must read as empty default: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// (3) The snapshot data region is read-only: a store into it must fault and
+/// abort the instruction; the on-chain subaccount stays unchanged. The
+/// `Custom(0xC5)` sentinel (returned only if the write was wrongly accepted)
+/// must NOT be the failure reason.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_read_only_cannot_modify() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"readonly-subaccount-snapshot-v1"; // 31 bytes
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=12 — load snapshot then try to write into its data region.
+    let mut data = vec![12u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_err(),
+        "writing a read-only subaccount snapshot must fail\nlogs:\n{}",
+        logs.join("\n")
+    );
+    assert_ne!(
+        status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(0xC5)
+        )),
+        "the write was wrongly accepted (program reached the post-write sentinel)\nlogs:\n{}",
+        logs.join("\n"),
+    );
+
+    let storage_addr = subaccount_storage_addr_for(&base_pubkey, &program_id);
+    assert_eq!(
+        bank.get_account(&storage_addr)
+            .expect("subaccount exists")
+            .data(),
+        v1,
+        "a snapshot read must never modify the underlying subaccount",
+    );
+}
+
+/// (4) Loading the same subaccount snapshot twice in one instruction must fail
+/// with `AccountAlreadyInitialized`.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_same_twice_fails() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"double-loaded-subaccount-snap_v"; // 31 bytes
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=13 — load twice.
+    let mut data = vec![13u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert_eq!(
+        status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::AccountAlreadyInitialized
+        )),
+        "loading the same subaccount snapshot twice must fail: {status:?}\nlogs:\n{}",
+        logs.join("\n"),
+    );
+}
+
+/// (5) A snapshot slot can be reused: load → unload → reload the same
+/// subaccount in a single instruction must succeed.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_unload_and_reload() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"reusable-subaccount-snap-slot_v"; // 31 bytes
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=14 — load + verify + unload + reload + verify + unload.
+    let mut data = vec![14u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    data.extend_from_slice(v1);
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "unload + reload of a subaccount snapshot failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// (6) Two distinct subaccounts can be snapshot-loaded into two slots at once
+/// and each reads back its own data.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_two_distinct() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let payer_pubkey = mint_keypair.pubkey();
+    let base1 = Pubkey::new_unique();
+    let base2 = Pubkey::new_unique();
+    let d1: &[u8] = b"first-subaccount-snapshot"; // 25 bytes
+    let d2: &[u8] = b"second-subaccount-snapshot-data-longer"; // 38 bytes
+
+    let ix1 = subaccount_create_instruction(program_id, base1, payer_pubkey, 0, d1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create #1 failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+    let ix2 = subaccount_create_instruction(program_id, base2, payer_pubkey, 0, d2, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix2);
+    assert!(
+        status.is_ok(),
+        "create #2 failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=15 — base1 ++ base2 ++ len(d1) as u16 LE ++ d1 ++ d2.
+    let mut data = vec![15u8];
+    data.extend_from_slice(base1.as_ref());
+    data.extend_from_slice(base2.as_ref());
+    data.extend_from_slice(&(d1.len() as u16).to_le_bytes());
+    data.extend_from_slice(d1);
+    data.extend_from_slice(d2);
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "two concurrent subaccount snapshots failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// (7) Within one instruction, a writable load that overwrites the subaccount
+/// with V2 does not affect a snapshot of the same subaccount, which still reads
+/// the start-of-block value V1. The writable overwrite is committed to V2.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_independent_from_writable_load() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"snap-start-of-block-value-v1___"; // 31 bytes
+    let v2: &[u8] = b"live-writable-overwrite-value_2"; // 31 bytes, same len
+    assert_eq!(v1.len(), v2.len());
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create V1.
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block N so V1 is the start-of-block (parent) value.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N");
+
+    // disc=16 — base must be writable for the writable load. Payload =
+    // len(v1) as u16 LE ++ v1 (expected snapshot) ++ v2 (live overwrite).
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&(v1.len() as u16).to_le_bytes());
+    payload.extend_from_slice(v1);
+    payload.extend_from_slice(v2);
+    let ix = subaccount_instruction(program_id, base_pubkey, true, 16, &payload, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "snapshot must stay independent of the live writable load: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // The writable overwrite was committed — live on-chain state is now V2.
+    let storage_addr = subaccount_storage_addr_for(&base_pubkey, &program_id);
+    assert_eq!(
+        bank.get_account(&storage_addr)
+            .expect("subaccount exists")
+            .data(),
+        v2,
+        "the writable overwrite should have committed V2",
+    );
+}
+
+/// (8) A snapshot reads the *parent slot's committed* state, not the original
+/// creation value: V1 created in block A, overwritten + committed to V2 in
+/// block B, snapshot-read in block C must return V2 (block B is C's parent).
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_tracks_parent_not_origin() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"origin-creation-value-block-a_1"; // 31 bytes
+    let v2: &[u8] = b"committed-parent-value-block-b2"; // 31 bytes, same len
+    assert_eq!(v1.len(), v2.len());
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create V1.
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block B and commit an overwrite to V2 (load + overwrite + unload).
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block B");
+    let ix2 = subaccount_instruction(program_id, base_pubkey, true, 1, v2, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix2);
+    assert!(
+        status.is_ok(),
+        "block B overwrite failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block C — the snapshot must observe V2 (parent slot B), not V1.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block C");
+    let mut data = vec![10u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    data.extend_from_slice(v2);
+    let ix3 = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix3);
+    assert!(
+        status.is_ok(),
+        "snapshot must read the parent-slot committed V2, not the origin V1: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+// ============================================================================
+// `sol_load_account_snapshot` — read-only, base-free, start-of-block load of an
+// arbitrary account *by pubkey* (not subaccount seeds). Mirrors the subaccount
+// snapshot tests above but exercises the `SnapshotKey::Account` lane.
+// ============================================================================
+
+/// Build an `AccountSharedData` with explicit lamports / owner / data.
+#[cfg(feature = "sbf_rust")]
+fn make_account(lamports: u64, owner: &Pubkey, data: &[u8]) -> AccountSharedData {
+    let mut account = AccountSharedData::new(lamports, data.len(), owner);
+    account.set_data_from_slice(data);
+    account
+}
+
+/// Build a disc=11 `load_account_snapshot_verify` instruction: read the
+/// start-of-block snapshot of `account_pk` and assert owner / lamports /
+/// data_len / data match. No account metas — proves the read is base-free.
+#[cfg(feature = "sbf_rust")]
+fn account_snapshot_verify_instruction(
+    program_id: Pubkey,
+    account_pk: &Pubkey,
+    expected_owner: &Pubkey,
+    expected_lamports: u64,
+    expected_data: &[u8],
+) -> Instruction {
+    let mut data = vec![17u8];
+    data.extend_from_slice(account_pk.as_ref());
+    data.extend_from_slice(expected_owner.as_ref());
+    data.extend_from_slice(&expected_lamports.to_le_bytes());
+    data.extend_from_slice(expected_data);
+    Instruction::new_with_bytes(program_id, &data, vec![])
+}
+
+/// Happy path: an account written in one block is snapshot-read by pubkey in the
+/// next block with NO account in the transaction. The snapshot's owner,
+/// lamports, data_len and data must all match the start-of-block state.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_reads_block_start_without_account() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let lamports = 1_234_567u64;
+    let v1: &[u8] = b"account-snapshot-block-start-v1"; // 31 bytes
+
+    // Block A — store the account.
+    bank.store_account(&account_pk, &make_account(lamports, &owner, v1));
+
+    // Advance so the write lives in the parent slot.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    let ix = account_snapshot_verify_instruction(program_id, &account_pk, &owner, lamports, v1);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "base-free account snapshot read failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// A snapshot read sees the start-of-block state even when an earlier write in
+/// the same block has overwritten the account: the snapshot observes the
+/// parent-slot value, not the live mid-block one.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_ignores_midblock_write() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let lamports = 7_654_321u64;
+    let v1: &[u8] = b"acct-snapshot-block-start-val-1"; // 31 bytes
+    let v2: &[u8] = b"acct-midblock-overwrite-val-2__"; // 31 bytes, same len
+    assert_eq!(v1.len(), v2.len());
+
+    // Block A — store V1.
+    bank.store_account(&account_pk, &make_account(lamports, &owner, v1));
+
+    // Advance to block N.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N");
+
+    // Mid-block write into the live slot N — overwrite with V2.
+    bank.store_account(&account_pk, &make_account(lamports, &owner, v2));
+    assert_eq!(
+        bank.get_account(&account_pk).expect("account exists").data(),
+        v2,
+        "mid-block overwrite should be the live state",
+    );
+
+    // The snapshot read in the same block N must still see V1.
+    let ix = account_snapshot_verify_instruction(program_id, &account_pk, &owner, lamports, v1);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "snapshot must read start-of-block V1, not mid-block V2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// Snapshot-reading a pubkey that was never created returns the default empty
+/// state (zero owner / zero lamports / empty data) rather than erroring.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_missing_account_is_empty() {
+    let (_bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+
+    // Advance a slot so the read has a parent slot to consult; the account is
+    // absent in every ancestor.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    let ix =
+        account_snapshot_verify_instruction(program_id, &account_pk, &Pubkey::default(), 0, &[]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "missing-account snapshot must read as empty default: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// The snapshot data region is read-only: a store into it must fault and abort
+/// the instruction. The on-chain account must be unchanged afterwards (a
+/// snapshot is never persisted). The `Custom(0xB5)` sentinel — returned only if
+/// the write was wrongly accepted — must NOT be the failure reason.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_read_only_cannot_modify() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let v1: &[u8] = b"readonly-account-snapshot-data_"; // 31 bytes
+
+    bank.store_account(&account_pk, &make_account(42, &owner, v1));
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=18 — load snapshot then try to write into its data region.
+    let mut data = vec![18u8];
+    data.extend_from_slice(account_pk.as_ref());
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_err(),
+        "writing a read-only account snapshot must fail\nlogs:\n{}",
+        logs.join("\n")
+    );
+    assert_ne!(
+        status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(0xB5)
+        )),
+        "the write was wrongly accepted (program reached the post-write sentinel)\nlogs:\n{}",
+        logs.join("\n"),
+    );
+
+    // The original account is untouched.
+    assert_eq!(
+        bank.get_account(&account_pk).expect("account exists").data(),
+        v1,
+        "a snapshot read must never modify the underlying account",
+    );
+}
+
+/// Loading the same account snapshot twice in one instruction must fail with
+/// `AccountAlreadyInitialized`.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_same_account_twice_fails() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let v1: &[u8] = b"double-loaded-account-snapshot_"; // 31 bytes
+
+    bank.store_account(&account_pk, &make_account(42, &owner, v1));
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=19 — load twice.
+    let mut data = vec![19u8];
+    data.extend_from_slice(account_pk.as_ref());
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert_eq!(
+        status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::AccountAlreadyInitialized
+        )),
+        "loading the same account snapshot twice must fail: {status:?}\nlogs:\n{}",
+        logs.join("\n"),
+    );
+}
+
+/// A snapshot slot can be reused: load → unload → reload the same account in a
+/// single instruction must succeed.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_unload_and_reload() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let account_pk = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let v1: &[u8] = b"reusable-account-snapshot-slot_"; // 31 bytes
+
+    bank.store_account(&account_pk, &make_account(42, &owner, v1));
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=20 — load + verify + unload + reload + verify + unload.
+    let mut data = vec![20u8];
+    data.extend_from_slice(account_pk.as_ref());
+    data.extend_from_slice(v1);
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "unload + reload of an account snapshot failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// Two distinct accounts can be snapshot-loaded into two slots at once and each
+/// reads back its own data.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_two_distinct_accounts() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let pk1 = Pubkey::new_unique();
+    let pk2 = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let d1: &[u8] = b"first-account-snapshot-data"; // 27 bytes
+    let d2: &[u8] = b"second-account-snapshot-data-longer-payload"; // 43 bytes
+
+    bank.store_account(&pk1, &make_account(11, &owner, d1));
+    bank.store_account(&pk2, &make_account(22, &owner, d2));
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=21 — pk1 ++ pk2 ++ len(d1) as u16 LE ++ d1 ++ d2.
+    let mut data = vec![21u8];
+    data.extend_from_slice(pk1.as_ref());
+    data.extend_from_slice(pk2.as_ref());
+    data.extend_from_slice(&(d1.len() as u16).to_le_bytes());
+    data.extend_from_slice(d1);
+    data.extend_from_slice(d2);
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "two concurrent account snapshots failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// `SnapshotKey::Account(pk)` and `SnapshotKey::Subaccount(pk)` never collide,
+/// even when the account snapshot is pointed at the subaccount's *derived*
+/// address: each resolves to an independent lane entry with its own data.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_account_snapshot_vs_subaccount_snapshot_distinct_keys() {
+    use solana_transaction_context::create_subaccount_address;
+
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+    let subaccount_data: &[u8] = b"subaccount-lane-distinct-value_"; // 31 bytes
+    let account_data: &[u8] = b"account-lane-distinct-value-different-bytes"; // 43 bytes
+
+    // The subaccount's owner-facing derived address.
+    let derived = create_subaccount_address(&[base_pubkey.as_ref(), SUBACCOUNT_SEED_TAG], &program_id)
+        .expect("derive subaccount address");
+
+    // Block A — create the subaccount (writes `subaccount_data` to the
+    // subaccount storage), and independently store a regular account *at the
+    // derived address itself* with different bytes.
+    let ix_create = subaccount_create_instruction(
+        program_id,
+        base_pubkey,
+        payer_pubkey,
+        0,
+        subaccount_data,
+        vec![],
+    );
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix_create);
+    assert!(
+        status.is_ok(),
+        "subaccount create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+    bank.store_account(
+        &derived,
+        &make_account(99, &Pubkey::new_unique(), account_data),
+    );
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // disc=22 — base ++ derived ++ len(account_data) as u16 LE ++ account_data
+    //           ++ subaccount_data. Reads both snapshots and checks each lane.
+    let mut data = vec![22u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    data.extend_from_slice(derived.as_ref());
+    data.extend_from_slice(&(account_data.len() as u16).to_le_bytes());
+    data.extend_from_slice(account_data);
+    data.extend_from_slice(subaccount_data);
+    let ix = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix);
+    assert!(
+        status.is_ok(),
+        "account/subaccount snapshot keys must not collide: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_subaccount_cant_modify_readonly_data() {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -6076,6 +6076,112 @@ fn test_program_sbf_subaccount_persists_across_transactions() {
     assert_eq!(stored.owner(), &program_id);
 }
 
+/// `sol_load_subaccount_snapshot_*` reads the start-of-block (parent-slot)
+/// state and does not require the base account to be present in the
+/// transaction. Here the subaccount is created in one block and snapshot-read
+/// in the next, with the base account deliberately omitted from the reading
+/// transaction (disc=10 takes the base pubkey from instruction data).
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_reads_block_start_without_base() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"snapshot-marker-v1_____________"; // 31 bytes
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create the subaccount with V1.
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to a child block so the V1 write lives in the parent slot.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for snapshot read");
+
+    // Snapshot-read with NO base account in the transaction (empty account
+    // metas). Payload = base pubkey ++ expected start-of-block bytes (V1).
+    let mut data = vec![10u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    data.extend_from_slice(v1);
+    let ix2 = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix2);
+    assert!(
+        status.is_ok(),
+        "base-free snapshot read failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
+/// A `sol_load_subaccount_snapshot_*` read sees the start-of-block state even
+/// when an earlier transaction in the same block has overwritten the
+/// subaccount: the snapshot must observe the parent-slot value, not the live
+/// mid-block one.
+#[test]
+#[cfg(feature = "sbf_rust")]
+fn test_program_sbf_subaccount_snapshot_ignores_midblock_write() {
+    let (bank, mut bank_client, bank_forks, mint_keypair, program_id) =
+        deploy_subaccount_program(1_000_000_000);
+
+    let v1: &[u8] = b"snapshot-block-start-value-v1__"; // 31 bytes
+    let v2: &[u8] = b"midblock-overwrite-value-v2____"; // 31 bytes, same len
+    assert_eq!(v1.len(), v2.len());
+    let payer_pubkey = mint_keypair.pubkey();
+    let base_pubkey = Pubkey::new_unique();
+
+    // Block A — create with V1.
+    let ix1 = subaccount_create_instruction(program_id, base_pubkey, payer_pubkey, 0, v1, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix1);
+    assert!(
+        status.is_ok(),
+        "create failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Advance to block N.
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
+        .expect("advance slot for block N");
+
+    // Tx1 in block N — overwrite the subaccount mid-block with V2.
+    let ix2 = subaccount_instruction(program_id, base_pubkey, true, 1, v2, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix2);
+    assert!(
+        status.is_ok(),
+        "mid-block overwrite failed: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+
+    // Sanity: the live mid-block state is now V2.
+    let storage_addr = subaccount_storage_addr_for(&base_pubkey, &program_id);
+    assert_eq!(
+        bank.get_account(&storage_addr)
+            .expect("subaccount exists")
+            .data(),
+        v2,
+        "mid-block overwrite should be the live state",
+    );
+
+    // Tx2 in the SAME block N — the snapshot read must still see V1 (the
+    // start-of-block / parent-slot value), not the mid-block V2.
+    let mut data = vec![10u8];
+    data.extend_from_slice(base_pubkey.as_ref());
+    data.extend_from_slice(v1);
+    let ix3 = Instruction::new_with_bytes(program_id, &data, vec![]);
+    let (status, _, logs) = run_subaccount_tx(&bank, &mint_keypair, ix3);
+    assert!(
+        status.is_ok(),
+        "snapshot must read start-of-block V1, not mid-block V2: {status:?}\nlogs:\n{}",
+        logs.join("\n")
+    );
+}
+
 #[test]
 #[cfg(feature = "sbf_rust")]
 fn test_program_sbf_subaccount_cant_modify_readonly_data() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -179,7 +179,7 @@ use {
                 AtomicBool, AtomicI64, AtomicU64,
                 Ordering::{self, AcqRel, Acquire, Relaxed},
             },
-            Arc, LockResult, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+            Arc, LockResult, Mutex, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
         },
         time::{Duration, Instant},
     },
@@ -515,6 +515,7 @@ impl PartialEq for Bank {
             status_cache: _,
             blockhash_queue,
             ancestors,
+            parent_ancestors: _,
             hash,
             parent_hash,
             parent_slot,
@@ -740,6 +741,14 @@ pub struct Bank {
 
     /// The set of parents including this bank
     pub ancestors: Ancestors,
+
+    /// Lazily-memoized parent ancestor set: `ancestors` with `self.slot`
+    /// removed. `ancestors` is fixed at bank construction, so this is constant
+    /// for the bank's lifetime. The snapshot read path
+    /// (`get_account_shared_data_at_block_start`) builds it once and reuses it
+    /// across every distinct snapshot account, instead of cloning `ancestors`
+    /// and removing `self.slot` on each call.
+    parent_ancestors: OnceLock<Ancestors>,
 
     /// Hash of this Bank's state. Only meaningful after freezing.
     hash: RwLock<Hash>,
@@ -1071,6 +1080,7 @@ impl Bank {
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             ancestors: Ancestors::default(),
+            parent_ancestors: OnceLock::new(),
             hash: RwLock::<Hash>::default(),
             parent_hash: Hash::default(),
             parent_slot: Slot::default(),
@@ -1340,6 +1350,7 @@ impl Bank {
             collector_id: *collector_id,
             collector_fees: AtomicU64::new(0),
             ancestors: Ancestors::default(),
+            parent_ancestors: OnceLock::new(),
             hash: RwLock::new(Hash::default()),
             is_delta: AtomicBool::new(false),
             tick_height: AtomicU64::new(parent.tick_height.load(Relaxed)),
@@ -1811,6 +1822,7 @@ impl Bank {
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             ancestors,
+            parent_ancestors: OnceLock::new(),
             hash: RwLock::new(fields.hash),
             parent_hash: fields.parent_hash,
             parent_slot: fields.parent_slot,
@@ -5872,14 +5884,20 @@ impl TransactionProcessingCallback for Bank {
     ) -> Option<(AccountSharedData, Slot)> {
         // Read with the current slot excluded so writes made by earlier
         // transactions in this block are invisible — i.e. the account as of the
-        // block's parent slot. `proper_ancestors()` is fixed at bank
+        // block's parent slot. The parent ancestor set is fixed at bank
         // construction and identical across leader and replay, so the result is
-        // deterministic across the cluster.
-        let ancestors = Ancestors::from(self.proper_ancestors().collect::<Vec<_>>());
+        // deterministic across the cluster. It is memoized on first use
+        // (`parent_ancestors`) and reused across every snapshot load in the
+        // transaction rather than cloned per distinct account.
+        let parent_ancestors = self.parent_ancestors.get_or_init(|| {
+            let mut ancestors = self.ancestors.clone();
+            ancestors.remove(&self.slot);
+            ancestors
+        });
         self.rc
             .accounts
             .accounts_db
-            .load_with_fixed_root(&ancestors, pubkey)
+            .load_with_fixed_root(parent_ancestors, pubkey)
     }
 
     fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2078,8 +2078,7 @@ impl Bank {
         // of this function. With offset==0 (production default) this is a
         // no-op.
         let last_offset = crate::parasol_clock_offset::last_applied();
-        let mut unix_timestamp =
-            self.clock().unix_timestamp.saturating_sub(last_offset);
+        let mut unix_timestamp = self.clock().unix_timestamp.saturating_sub(last_offset);
         // set epoch_start_timestamp to None to warp timestamp
         let epoch_start_timestamp = {
             let epoch = if let Some(epoch) = parent_epoch {
@@ -2095,8 +2094,7 @@ impl Bank {
             slow: MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
         };
 
-        let ancestor_timestamp =
-            self.clock().unix_timestamp.saturating_sub(last_offset);
+        let ancestor_timestamp = self.clock().unix_timestamp.saturating_sub(last_offset);
         if let Some(timestamp_estimate) =
             self.get_timestamp_estimate(max_allowable_drift, epoch_start_timestamp)
         {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5868,6 +5868,22 @@ impl TransactionProcessingCallback for Bank {
             .load_with_fixed_root(&self.ancestors, pubkey)
     }
 
+    fn get_account_shared_data_at_block_start(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        // Read with the current slot excluded so writes made by earlier
+        // transactions in this block are invisible — i.e. the account as of the
+        // block's parent slot. `proper_ancestors()` is fixed at bank
+        // construction and identical across leader and replay, so the result is
+        // deterministic across the cluster.
+        let ancestors = Ancestors::from(self.proper_ancestors().collect::<Vec<_>>());
+        self.rc
+            .accounts
+            .accounts_db
+            .load_with_fixed_root(&ancestors, pubkey)
+    }
+
     fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
         self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
     }

--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -44,6 +44,23 @@ pub trait InvokeContextCallback {
 pub trait TransactionProcessingCallback: InvokeContextCallback {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
 
+    /// Load `pubkey` as of the beginning of the current block (parent-slot
+    /// state), before any transaction in this block modified it. Used by the
+    /// read-only `sol_load_subaccount_snapshot_*` syscalls to expose a
+    /// deterministic start-of-block snapshot independent of intra-block
+    /// ordering.
+    ///
+    /// The default implementation falls back to the live mid-block read so
+    /// non-bank contexts (tests / svm-internal harnesses, which generally run
+    /// a single slot) keep working unchanged. `Bank` overrides this to read
+    /// with the current slot excluded.
+    fn get_account_shared_data_at_block_start(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.get_account_shared_data(pubkey)
+    }
+
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
     }
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -362,6 +362,17 @@ impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for Accoun
         // but will later be used in IndexImplementation::V2 of the global program cache.
         self.do_load(pubkey).0.map(|account| (account, 0))
     }
+
+    fn get_account_shared_data_at_block_start(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        // Deliberately bypass `self.loaded_accounts` (the mid-block cache that
+        // `update_accounts_for_executed_tx` populates with this block's writes)
+        // and delegate straight to the underlying callback (the bank), whose
+        // implementation reads the account as of the block's parent slot.
+        self.callbacks.get_account_shared_data_at_block_start(pubkey)
+    }
 }
 
 // NOTE this is a required subtrait of TransactionProcessingCallback.

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -371,7 +371,8 @@ impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for Accoun
         // `update_accounts_for_executed_tx` populates with this block's writes)
         // and delegate straight to the underlying callback (the bank), whose
         // implementation reads the account as of the block's parent slot.
-        self.callbacks.get_account_shared_data_at_block_start(pubkey)
+        self.callbacks
+            .get_account_shared_data_at_block_start(pubkey)
     }
 }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -537,7 +537,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         config,
                     );
 
-
                     match (
                         &executed_tx.execution_details.status,
                         config.drop_on_failure,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -15,7 +15,7 @@ pub use self::{
     mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
     subaccount::{
         SyscallCreateSubaccount, SyscallLoadSubaccountC, SyscallLoadSubaccountRust,
-        SyscallLoadSubaccountSnapshot, SyscallReadSubaccount,
+        SyscallLoadAccountSnapshot, SyscallLoadSubaccountSnapshot, SyscallReadSubaccount,
         SyscallUnloadSubaccount,
     },
     sysvar::{
@@ -457,6 +457,7 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     result.register_function("sol_load_subaccount_c", SyscallLoadSubaccountC::vm)?;
     // F10: read-only, base-free, start-of-block (parent-slot) snapshot loads.
     result.register_function("sol_load_subaccount_snapshot", SyscallLoadSubaccountSnapshot::vm)?;
+    result.register_function("sol_load_account_snapshot", SyscallLoadAccountSnapshot::vm)?;
     result.register_function("sol_read_subaccount", SyscallReadSubaccount::vm)?;
     result.register_function("sol_unload_subaccount", SyscallUnloadSubaccount::vm)?;
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -15,7 +15,8 @@ pub use self::{
     mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
     subaccount::{
         SyscallCreateSubaccount, SyscallLoadSubaccountC, SyscallLoadSubaccountRust,
-        SyscallReadSubaccount, SyscallUnloadSubaccount,
+        SyscallLoadSubaccountSnapshot, SyscallReadSubaccount,
+        SyscallUnloadSubaccount,
     },
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
@@ -454,6 +455,8 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     result.register_function("sol_create_subaccount", SyscallCreateSubaccount::vm)?;
     result.register_function("sol_load_subaccount_rust", SyscallLoadSubaccountRust::vm)?;
     result.register_function("sol_load_subaccount_c", SyscallLoadSubaccountC::vm)?;
+    // F10: read-only, base-free, start-of-block (parent-slot) snapshot loads.
+    result.register_function("sol_load_subaccount_snapshot", SyscallLoadSubaccountSnapshot::vm)?;
     result.register_function("sol_read_subaccount", SyscallReadSubaccount::vm)?;
     result.register_function("sol_unload_subaccount", SyscallUnloadSubaccount::vm)?;
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -14,8 +14,8 @@ pub use self::{
     },
     mem_ops::{SyscallMemcmp, SyscallMemcpy, SyscallMemmove, SyscallMemset},
     subaccount::{
-        SyscallCreateSubaccount, SyscallLoadSubaccountC, SyscallLoadSubaccountRust,
-        SyscallLoadAccountSnapshot, SyscallLoadSubaccountSnapshot, SyscallReadSubaccount,
+        SyscallCreateSubaccount, SyscallLoadAccountSnapshot, SyscallLoadSubaccountC,
+        SyscallLoadSubaccountRust, SyscallLoadSubaccountSnapshot, SyscallReadSubaccount,
         SyscallUnloadSubaccount,
     },
     sysvar::{
@@ -456,7 +456,10 @@ pub fn create_program_runtime_environment_v1<'a, 'ix_data>(
     result.register_function("sol_load_subaccount_rust", SyscallLoadSubaccountRust::vm)?;
     result.register_function("sol_load_subaccount_c", SyscallLoadSubaccountC::vm)?;
     // F10: read-only, base-free, start-of-block (parent-slot) snapshot loads.
-    result.register_function("sol_load_subaccount_snapshot", SyscallLoadSubaccountSnapshot::vm)?;
+    result.register_function(
+        "sol_load_subaccount_snapshot",
+        SyscallLoadSubaccountSnapshot::vm,
+    )?;
     result.register_function("sol_load_account_snapshot", SyscallLoadAccountSnapshot::vm)?;
     result.register_function("sol_read_subaccount", SyscallReadSubaccount::vm)?;
     result.register_function("sol_unload_subaccount", SyscallUnloadSubaccount::vm)?;

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -121,11 +121,11 @@ fn find_or_add_snapshot(
         snapshot_index
     } else {
         let storage_address = match snapshot_key {
-            SnapshotKey::Account(pubkey) => pubkey,
-            SnapshotKey::Subaccount(pubkey) => &subaccount_storage_address(pubkey),
+            SnapshotKey::Account(pubkey) => *pubkey,
+            SnapshotKey::Subaccount(pubkey) => subaccount_storage_address(pubkey),
         };
         let (snapshot, _slot) = invoke_context
-            .get_account_shared_data_at_block_start(storage_address)
+            .get_account_shared_data_at_block_start(&storage_address)
             .unwrap_or_else(|| (AccountSharedData::default(), 0));
         let data_len_cost = (snapshot.data().len() as u64)
             .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
@@ -1119,6 +1119,8 @@ declare_builtin_function!(
 ///     (parent-slot state) via `get_account_shared_data_at_block_start`, then
 ///     stored in a fresh, deduplicated lane entry ([`add_snapshot`]) so the
 ///     snapshot is independent of any mid-block load of the same subaccount.
+///   - doesn't use account-locking model because the snapshot is read-only and 
+///     never persisted, so it doesn't need to be locked for reading or writing.
 ///
 /// The slot is released by the same `sol_unload_subaccount`.
 fn load_snapshot_impl(
@@ -1127,8 +1129,6 @@ fn load_snapshot_impl(
     memory_mapping: &mut MemoryMapping,
     get_snapshot_key: impl FnOnce(&mut InvokeContext, &mut MemoryMapping) -> Result<SnapshotKey, Error>,
 ) -> Result<u64, Error> {
-    check_subaccount_syscall_enabled(invoke_context, "sol_load_subaccount_snapshot")?;
-
     let mut load_subaccount_time = Measure::start("load_subaccount");
     let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
     consume_compute_meter(invoke_context, syscall_base_cost)?;
@@ -1241,6 +1241,7 @@ declare_builtin_function!(
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        check_subaccount_syscall_enabled(invoke_context, "sol_load_subaccount_snapshot")?;
         load_snapshot_impl(
             invoke_context,
             out_header_addr,
@@ -1278,6 +1279,7 @@ declare_builtin_function!(
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        check_subaccount_syscall_enabled(invoke_context, "sol_load_account_snapshot")?;
         load_snapshot_impl(
             invoke_context,
             out_header_addr,

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -25,9 +25,9 @@ use {
     solana_svm_log_collector::ic_msg,
     solana_system_interface::instruction::SystemInstruction,
     solana_transaction_context::{
-        create_subaccount_address, subaccount_storage_address, vm_slice::VmSlice, IndexOfAccount,
-        InstructionAccount, MAX_ACCOUNTS_PER_TRANSACTION, SUBACCOUNT_MARKER,
-        transaction_accounts::SnapshotKey,
+        create_subaccount_address, subaccount_storage_address, transaction_accounts::SnapshotKey,
+        vm_slice::VmSlice, IndexOfAccount, InstructionAccount, MAX_ACCOUNTS_PER_TRANSACTION,
+        SUBACCOUNT_MARKER,
     },
 };
 
@@ -617,7 +617,10 @@ impl SubaccountDataGuard {
             syscall_context
                 .subaccount_slots
                 .iter()
-                .find(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
+                .find(|s| {
+                    s.occupied_subaccount_index
+                        == OccupiedSubaccountIndex::Subaccount(subaccount_index)
+                })
                 .map(|s| (s.vm_data_addr, s.is_writable))
         };
         let Some((vm_data_addr, is_writable)) = slot_info else {
@@ -707,7 +710,9 @@ fn sync_subaccount_slot_after_mutation(
         syscall_context
             .subaccount_slots
             .iter()
-            .find(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
+            .find(|s| {
+                s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index)
+            })
             .and_then(
                 |s| match (s.caller_account_metadata.as_ref(), s.account_view_kind) {
                     (Some(m), Some(kind)) => Some((s.vm_account_view_addr, kind, m.clone())),
@@ -819,8 +824,8 @@ fn translate_subaccount_seeds_no_base(
 ) -> Result<Pubkey, Error> {
     let seeds =
         translate_subaccount_seed_slices(seeds_addr, seeds_len, memory_mapping, check_aligned)?;
-    let subaccount_pubkey =
-        create_subaccount_address(&seeds, program_id).map_err(|_| InstructionError::InvalidSeeds)?;
+    let subaccount_pubkey = create_subaccount_address(&seeds, program_id)
+        .map_err(|_| InstructionError::InvalidSeeds)?;
     Ok(subaccount_pubkey)
 }
 
@@ -967,11 +972,9 @@ fn load_subaccount_impl(
     // pick a free slot.
     let (slot_index, vm_header_addr, vm_data_addr, vm_account_view_addr) = {
         let syscall_context = invoke_context.get_syscall_context_mut()?;
-        if syscall_context
-            .subaccount_slots
-            .iter()
-            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
-        {
+        if syscall_context.subaccount_slots.iter().any(|s| {
+            s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index)
+        }) {
             ic_msg!(
                 invoke_context,
                 "sol_load_subaccount: subaccount {} is already loaded",
@@ -1114,7 +1117,7 @@ declare_builtin_function!(
 ///     region is mapped read-only and the entry is never touched/persisted; and
 ///   - the on-chain state is read **as of the beginning of the block**
 ///     (parent-slot state) via `get_account_shared_data_at_block_start`, then
-///     stored in a fresh, deduplicated lane entry ([`add_snapshot`]) so the 
+///     stored in a fresh, deduplicated lane entry ([`add_snapshot`]) so the
 ///     snapshot is independent of any mid-block load of the same subaccount.
 ///
 /// The slot is released by the same `sol_unload_subaccount`.
@@ -1135,7 +1138,7 @@ fn load_snapshot_impl(
     let snapshot_key = get_snapshot_key(invoke_context, memory_mapping)?;
     compute_subaccounts_time.stop();
     invoke_context.timings.compute_subaccounts_us += compute_subaccounts_time.as_us();
-    let is_writable = false;  // snapshot loads are always read-only
+    let is_writable = false; // snapshot loads are always read-only
 
     // Load the start-of-block on-chain state into the (deduplicated) snapshot
     // lane and snapshot a copy of the header fields for the slot. The snapshot
@@ -1158,11 +1161,9 @@ fn load_snapshot_impl(
     // snapshot index — refuse if a slot already holds it. Then pick a free slot.
     let (slot_index, vm_header_addr, vm_data_addr) = {
         let syscall_context = invoke_context.get_syscall_context_mut()?;
-        if syscall_context
-            .subaccount_slots
-            .iter()
-            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Snapshot(snapshot_index))
-        {
+        if syscall_context.subaccount_slots.iter().any(|s| {
+            s.occupied_subaccount_index == OccupiedSubaccountIndex::Snapshot(snapshot_index)
+        }) {
             ic_msg!(
                 invoke_context,
                 "sol_load_subaccount_snapshot: snapshot {} is already loaded",
@@ -1176,14 +1177,13 @@ fn load_snapshot_impl(
             .enumerate()
             .find(|(_, slot)| slot.occupied_subaccount_index.is_empty())
         else {
-            ic_msg!(invoke_context, "sol_load_subaccount_snapshot: all slots in use");
+            ic_msg!(
+                invoke_context,
+                "sol_load_subaccount_snapshot: all slots in use"
+            );
             return Err(InstructionError::MaxAccountsExceeded.into());
         };
-        (
-            slot_index,
-            slot.vm_header_addr,
-            slot.vm_data_addr,
-        )
+        (slot_index, slot.vm_header_addr, slot.vm_data_addr)
     };
 
     // Stamp the slot header with the loaded subaccount's metadata.
@@ -1201,12 +1201,7 @@ fn load_snapshot_impl(
     // Map the slot's data region read-only onto the snapshot-lane storage.
     // Snapshot reads use the independent snapshot lane (not the subaccount
     // lane), are always read-only, and are never touched/persisted.
-    install_snapshot_data_region(
-        invoke_context,
-        memory_mapping,
-        snapshot_index,
-        vm_data_addr,
-    )?;
+    install_snapshot_data_region(invoke_context, memory_mapping, snapshot_index, vm_data_addr)?;
 
     let metadata = SerializedAccountMetadata {
         original_data_len: data_len,

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -533,6 +533,39 @@ fn install_subaccount_data_region(
     Ok(())
 }
 
+/// Replaces the slot's data region with a **read-only** one backed by a
+/// snapshot-lane entry's storage. Mirrors [`install_subaccount_data_region`]'s
+/// read-only branch, but reads from the snapshot lane
+/// ([`get_snapshot`](solana_transaction_context::transaction_accounts)) rather
+/// than the subaccount lane — the two lanes use independent index spaces, and a
+/// snapshot read never write-locks or persists, so it is always read-only and
+/// must never be `touch`ed.
+///
+/// SAFETY: the host pointer captured in the `MemoryRegion` must remain valid
+/// for the lifetime of the VM. The snapshot lane is append-only and its
+/// `AccountSharedData` storage is pinned to the transaction context for the
+/// whole instruction's duration, so the slice address is stable.
+fn install_snapshot_data_region(
+    invoke_context: &mut InvokeContext,
+    memory_mapping: &mut MemoryMapping,
+    snapshot_index: solana_transaction_context::IndexOfAccount,
+    vm_data_addr: u64,
+) -> Result<(), Error> {
+    let snapshot = invoke_context
+        .transaction_context
+        .accounts()
+        .get_snapshot(snapshot_index)?;
+    let new_region = MemoryRegion::new_readonly(snapshot.data(), vm_data_addr);
+    drop(snapshot);
+    let (region_index, _) = memory_mapping
+        .find_region(vm_data_addr)
+        .ok_or(InstructionError::MissingAccount)?;
+    memory_mapping
+        .replace_region(region_index, new_region)
+        .map_err(|_| InstructionError::InvalidArgument)?;
+    Ok(())
+}
+
 /// Restores the slot's data region to the empty readonly placeholder so the
 /// next `sol_load_subaccount` call can install a fresh region.
 fn restore_subaccount_data_placeholder(
@@ -1166,14 +1199,14 @@ fn load_snapshot_impl(
         is_writable,
     )?;
 
-    // Map the slot's data region read-only onto the snapshot storage. Because
-    // `is_writable == false`, the entry is left untouched and never persisted.
-    install_subaccount_data_region(
+    // Map the slot's data region read-only onto the snapshot-lane storage.
+    // Snapshot reads use the independent snapshot lane (not the subaccount
+    // lane), are always read-only, and are never touched/persisted.
+    install_snapshot_data_region(
         invoke_context,
         memory_mapping,
         subaccount_index,
         vm_data_addr,
-        is_writable,
     )?;
 
     let metadata = SerializedAccountMetadata {
@@ -1369,7 +1402,7 @@ declare_builtin_function!(
         consume_compute_meter(invoke_context, syscall_base_cost)?;
         let check_aligned = invoke_context.get_check_aligned();
 
-        let (slot_index, subaccount_index, is_writable) = {
+        let (slot_index, occupied, is_writable, vm_data_addr) = {
             let syscall_context = invoke_context.get_syscall_context()?;
             let entry = syscall_context
                 .subaccount_slots
@@ -1384,16 +1417,50 @@ declare_builtin_function!(
                 );
                 return Err(InstructionError::InvalidArgument.into());
             };
-            let OccupiedSubaccountIndex::Subaccount(idx) = slot.occupied_subaccount_index else {
+            if slot.occupied_subaccount_index.is_empty() {
                 ic_msg!(
                     invoke_context,
                     "sol_unload_subaccount: slot at {:#x} is not loaded",
                     vm_header_addr,
                 );
                 return Err(InstructionError::InvalidArgument.into());
-            };
-            (slot_index, idx, slot.is_writable)
+            }
+            (
+                slot_index,
+                slot.occupied_subaccount_index,
+                slot.is_writable,
+                slot.vm_data_addr,
+            )
         };
+
+        // Read-only snapshot slots never mutated any lane and were direct-mapped
+        // read-only, so there is nothing to reconcile back into storage. Just
+        // restore the data placeholder, zero the header, and free the slot.
+        if let OccupiedSubaccountIndex::Snapshot(_) = occupied {
+            restore_subaccount_data_placeholder(memory_mapping, vm_data_addr)?;
+            write_subaccount_slot_header(
+                memory_mapping,
+                check_aligned,
+                vm_header_addr,
+                &Pubkey::default(),
+                &Pubkey::default(),
+                0,
+                0,
+                false,
+            )?;
+            let syscall_context = invoke_context.get_syscall_context_mut()?;
+            if let Some(slot) = syscall_context.subaccount_slots.get_mut(slot_index) {
+                slot.occupied_subaccount_index = OccupiedSubaccountIndex::Empty;
+                slot.caller_account_metadata = None;
+                slot.account_view_kind = None;
+                slot.is_writable = false;
+            }
+            return Ok(SUCCESS);
+        }
+
+        let subaccount_index = occupied
+            .get_subaccount_index()
+            .ok_or(InstructionError::InvalidArgument)?;
 
         // Read header fields out of VM memory (lamports / owner / data_len).
         let owner_bytes: [u8; PUBKEY_BYTES] = {

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -27,6 +27,7 @@ use {
     solana_transaction_context::{
         create_subaccount_address, subaccount_storage_address, vm_slice::VmSlice, IndexOfAccount,
         InstructionAccount, MAX_ACCOUNTS_PER_TRANSACTION, SUBACCOUNT_MARKER,
+        transaction_accounts::SnapshotKey,
     },
 };
 
@@ -109,17 +110,20 @@ fn find_or_add_subaccount(
     Ok(subaccount_index)
 }
 
-fn find_or_add_subaccount_snapshot(
+fn find_or_add_snapshot(
     invoke_context: &mut InvokeContext,
-    snapshot_pubkey: Pubkey,
+    snapshot_key: &SnapshotKey,
 ) -> Result<IndexOfAccount, Error> {
     let snapshot_index = if let Some(snapshot_index) = invoke_context
         .transaction_context
-        .find_index_of_snapshot(&snapshot_pubkey)
+        .find_index_of_snapshot(&snapshot_key)
     {
         snapshot_index
     } else {
-        let storage_address = subaccount_storage_address(&snapshot_pubkey);
+        let storage_address = match snapshot_key {
+            SnapshotKey::Account(pubkey) => pubkey,
+            SnapshotKey::Subaccount(pubkey) => &subaccount_storage_address(pubkey),
+        };
         let (snapshot, _slot) = invoke_context
             .get_account_shared_data_at_block_start(&storage_address)
             .unwrap_or_else(|| (AccountSharedData::default(), 0));
@@ -130,7 +134,7 @@ fn find_or_add_subaccount_snapshot(
 
         invoke_context
             .transaction_context
-            .add_subaccount_snapshot(snapshot_pubkey, snapshot)?
+            .add_snapshot(snapshot_key, snapshot)?
     };
 
     Ok(snapshot_index)
@@ -1067,8 +1071,8 @@ declare_builtin_function!(
     }
 );
 
-/// Shared body of the read-only `sol_load_subaccount_snapshot_{rust,c}`
-/// syscalls.
+/// Shared body of the read-only `sol_load_subaccount_snapshot` and
+/// `sol_load_account_snapshot` syscalls.
 ///
 /// Like [`load_subaccount_impl`], but:
 ///   - it does **not** require a base account in the transaction — the address
@@ -1078,17 +1082,15 @@ declare_builtin_function!(
 ///     region is mapped read-only and the entry is never touched/persisted; and
 ///   - the on-chain state is read **as of the beginning of the block**
 ///     (parent-slot state) via `get_account_shared_data_at_block_start`, then
-///     stored in a fresh, non-deduplicated lane entry
-///     ([`add_readonly_subaccount_snapshot`]) so the snapshot is independent of
-///     any mid-block load of the same subaccount.
+///     stored in a fresh, deduplicated lane entry ([`add_snapshot`]) so the 
+///     snapshot is independent of any mid-block load of the same subaccount.
 ///
 /// The slot is released by the same `sol_unload_subaccount`.
-fn load_subaccount_snapshot_impl(
+fn load_snapshot_impl(
     invoke_context: &mut InvokeContext,
-    seeds_addr: u64,
-    seeds_len: u64,
     out_header_addr: u64,
     memory_mapping: &mut MemoryMapping,
+    get_snapshot_key: impl FnOnce(&mut InvokeContext, &mut MemoryMapping) -> Result<SnapshotKey, Error>,
 ) -> Result<u64, Error> {
     check_subaccount_syscall_enabled(invoke_context, "sol_load_subaccount_snapshot")?;
 
@@ -1098,21 +1100,7 @@ fn load_subaccount_snapshot_impl(
     let check_aligned = invoke_context.get_check_aligned();
 
     let mut compute_subaccounts_time = Measure::start("compute_subaccounts");
-    // Translate seeds → derive PDA. Read-only snapshot loads never require a
-    // base account, so writability is unconditionally false.
-    let snapshot_pubkey = {
-        let instruction_context = invoke_context
-            .transaction_context
-            .get_current_instruction_context()?;
-        let program_id = *instruction_context.get_program_key()?;
-        translate_subaccount_seeds_no_base(
-            &program_id,
-            seeds_addr,
-            seeds_len,
-            memory_mapping,
-            check_aligned,
-        )?
-    };
+    let snapshot_key = get_snapshot_key(invoke_context, memory_mapping)?;
     compute_subaccounts_time.stop();
     invoke_context.timings.compute_subaccounts_us += compute_subaccounts_time.as_us();
     let is_writable = false;  // snapshot loads are always read-only
@@ -1121,11 +1109,11 @@ fn load_subaccount_snapshot_impl(
     // non-deduplicated lane entry so it is independent of any mid-block load of
     // the same subaccount. Snapshot a copy of the header fields for the slot.
     let (subaccount_index, data_len, lamports, owner_bytes) = {
-        let snapshot_index = find_or_add_subaccount_snapshot(invoke_context, snapshot_pubkey)?;
+        let snapshot_index = find_or_add_snapshot(invoke_context, &snapshot_key)?;
         let snapshot = invoke_context
             .transaction_context
             .accounts()
-            .get_subaccount_snapshot(snapshot_index)?;
+            .get_snapshot(snapshot_index)?;
         let data_len = snapshot.data().len();
         let lamports = snapshot.lamports();
         let owner_bytes = *snapshot.owner();
@@ -1145,8 +1133,8 @@ fn load_subaccount_snapshot_impl(
         {
             ic_msg!(
                 invoke_context,
-                "sol_load_subaccount_snapshot: subaccount snapshot {} is already loaded",
-                snapshot_pubkey,
+                "sol_load_subaccount_snapshot: snapshot {} is already loaded",
+                snapshot_key.as_pubkey(),
             );
             return Err(InstructionError::AccountAlreadyInitialized.into());
         }
@@ -1171,7 +1159,7 @@ fn load_subaccount_snapshot_impl(
         memory_mapping,
         check_aligned,
         vm_header_addr,
-        &snapshot_pubkey,
+        snapshot_key.as_pubkey(),
         &owner_bytes,
         lamports,
         data_len,
@@ -1215,8 +1203,7 @@ fn load_subaccount_snapshot_impl(
 
 declare_builtin_function!(
     /// F10: read-only, base-free, start-of-block load of a subaccount into a
-    /// pre-reserved VM slot. See
-    /// [`load_subaccount_snapshot_impl`] for the shared semantics.
+    /// pre-reserved VM slot. See [`load_subaccount_snapshot_impl`] for the shared semantics.
     SyscallLoadSubaccountSnapshot,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1227,12 +1214,55 @@ declare_builtin_function!(
         _arg5: u64,
         memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
-        load_subaccount_snapshot_impl(
+        load_snapshot_impl(
             invoke_context,
-            seeds_addr,
-            seeds_len,
             out_header_addr,
             memory_mapping,
+            |invoke_context, memory_mapping| {
+                // Translate seeds → derive PDA. Read-only snapshot loads never require a
+                // base account, so writability is unconditionally false.
+                let instruction_context = invoke_context
+                    .transaction_context
+                    .get_current_instruction_context()?;
+                let program_id = *instruction_context.get_program_key()?;
+                let snapshot_pubkey = translate_subaccount_seeds_no_base(
+                    &program_id,
+                    seeds_addr,
+                    seeds_len,
+                    memory_mapping,
+                    invoke_context.get_check_aligned(),
+                )?;
+                Ok(SnapshotKey::Subaccount(snapshot_pubkey))
+            }
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// F10: read-only, base-free, start-of-block load of a account into a
+    /// pre-reserved VM slot. See [`load_snapshot_impl`] for the shared semantics.
+    SyscallLoadAccountSnapshot,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        pubkey_addr: u64,
+        out_header_addr: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        load_snapshot_impl(
+            invoke_context,
+            out_header_addr,
+            memory_mapping,
+            |invoke_context, memory_mapping| {
+                let pubkey = *translate_type::<Pubkey>(
+                    memory_mapping,
+                    pubkey_addr,
+                    invoke_context.get_check_aligned(),
+                )?;
+                Ok(SnapshotKey::Account(pubkey))
+            }
         )
     }
 );

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -1,4 +1,4 @@
-use solana_program_runtime::memory::translate_vm_slice;
+use solana_program_runtime::{invoke_context::OccupiedSubaccountIndex, memory::translate_vm_slice};
 use solana_svm_measure::measure::Measure;
 use solana_svm_timings::ExecuteTimings;
 
@@ -108,6 +108,34 @@ fn find_or_add_subaccount(
 
     Ok(subaccount_index)
 }
+
+fn find_or_add_subaccount_snapshot(
+    invoke_context: &mut InvokeContext,
+    snapshot_pubkey: Pubkey,
+) -> Result<IndexOfAccount, Error> {
+    let snapshot_index = if let Some(snapshot_index) = invoke_context
+        .transaction_context
+        .find_index_of_snapshot(&snapshot_pubkey)
+    {
+        snapshot_index
+    } else {
+        let storage_address = subaccount_storage_address(&snapshot_pubkey);
+        let (snapshot, _slot) = invoke_context
+            .get_account_shared_data_at_block_start(&storage_address)
+            .unwrap_or_else(|| (AccountSharedData::default(), 0));
+        let data_len_cost = (snapshot.data().len() as u64)
+            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX);
+        consume_compute_meter(invoke_context, data_len_cost)?;
+
+        invoke_context
+            .transaction_context
+            .add_subaccount_snapshot(snapshot_pubkey, snapshot)?
+    };
+
+    Ok(snapshot_index)
+}
+
 // ============================================================================
 // F10 — Subaccounts syscalls (PRS-153)
 //
@@ -553,7 +581,7 @@ impl SubaccountDataGuard {
             syscall_context
                 .subaccount_slots
                 .iter()
-                .find(|s| s.occupied_subaccount_index == Some(subaccount_index))
+                .find(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
                 .map(|s| (s.vm_data_addr, s.is_writable))
         };
         let Some((vm_data_addr, is_writable)) = slot_info else {
@@ -643,7 +671,7 @@ fn sync_subaccount_slot_after_mutation(
         syscall_context
             .subaccount_slots
             .iter()
-            .find(|s| s.occupied_subaccount_index == Some(subaccount_index))
+            .find(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
             .and_then(
                 |s| match (s.caller_account_metadata.as_ref(), s.account_view_kind) {
                     (Some(m), Some(kind)) => Some((s.vm_account_view_addr, kind, m.clone())),
@@ -721,6 +749,45 @@ fn sync_subaccount_slot_after_mutation(
     data_guard.reinstall(invoke_context, memory_mapping)
 }
 
+/// Translate the VM seed array into host slices. Shared by the base-checked
+/// load/read path and the base-free snapshot path.
+fn translate_subaccount_seed_slices<'a>(
+    seeds_addr: u64,
+    seeds_len: u64,
+    memory_mapping: &'a MemoryMapping,
+    check_aligned: bool,
+) -> Result<Vec<&'a [u8]>, Error> {
+    let untranslated_seeds =
+        translate_slice::<VmSlice<u8>>(memory_mapping, seeds_addr, seeds_len, check_aligned)?;
+    if untranslated_seeds.len() > MAX_SEEDS {
+        return Err(Box::new(InstructionError::MaxSeedLengthExceeded));
+    }
+    untranslated_seeds
+        .iter()
+        .map(|untranslated_seed| {
+            translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
+        })
+        .collect::<Result<Vec<_>, Error>>()
+}
+
+/// Translate seeds and derive the subaccount address **without** requiring the
+/// base account (the first seed) to be present in the transaction. Used by the
+/// read-only `sol_load_subaccount_snapshot` syscalls, which never write-lock a
+/// base account because the load is read-only.
+fn translate_subaccount_seeds_no_base(
+    program_id: &Pubkey,
+    seeds_addr: u64,
+    seeds_len: u64,
+    memory_mapping: &MemoryMapping,
+    check_aligned: bool,
+) -> Result<Pubkey, Error> {
+    let seeds =
+        translate_subaccount_seed_slices(seeds_addr, seeds_len, memory_mapping, check_aligned)?;
+    let subaccount_pubkey =
+        create_subaccount_address(&seeds, program_id).map_err(|_| InstructionError::InvalidSeeds)?;
+    Ok(subaccount_pubkey)
+}
+
 fn translate_subaccount_seeds(
     program_id: &Pubkey,
     seeds_addr: u64,
@@ -730,17 +797,8 @@ fn translate_subaccount_seeds(
     invoke_context: &InvokeContext,
     instruction_context: &solana_transaction_context::InstructionContext,
 ) -> Result<(Pubkey, bool), Error> {
-    let untranslated_seeds =
-        translate_slice::<VmSlice<u8>>(memory_mapping, seeds_addr, seeds_len, check_aligned)?;
-    if untranslated_seeds.len() > MAX_SEEDS {
-        return Err(Box::new(InstructionError::MaxSeedLengthExceeded));
-    }
-    let seeds = untranslated_seeds
-        .iter()
-        .map(|untranslated_seed| {
-            translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
+    let seeds =
+        translate_subaccount_seed_slices(seeds_addr, seeds_len, memory_mapping, check_aligned)?;
     let base_seed: [u8; 32] = (*seeds.first().ok_or(InstructionError::InvalidArgument)?)
         .try_into()
         .map_err(|err: std::array::TryFromSliceError| {
@@ -876,7 +934,7 @@ fn load_subaccount_impl(
         if syscall_context
             .subaccount_slots
             .iter()
-            .any(|s| s.occupied_subaccount_index == Some(subaccount_index))
+            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Subaccount(subaccount_index))
         {
             ic_msg!(
                 invoke_context,
@@ -889,7 +947,7 @@ fn load_subaccount_impl(
             .subaccount_slots
             .iter_mut()
             .enumerate()
-            .find(|(_, slot)| slot.occupied_subaccount_index.is_none())
+            .find(|(_, slot)| slot.occupied_subaccount_index.is_empty())
         else {
             ic_msg!(invoke_context, "sol_load_subaccount: all slots in use");
             return Err(InstructionError::MaxAccountsExceeded.into());
@@ -941,7 +999,7 @@ fn load_subaccount_impl(
     let view_out = translate_type_mut::<u64>(memory_mapping, out_account_view_addr, check_aligned)?;
 
     if let Some(slot) = syscall_context.subaccount_slots.get_mut(slot_index) {
-        slot.occupied_subaccount_index = Some(subaccount_index);
+        slot.occupied_subaccount_index = OccupiedSubaccountIndex::Subaccount(subaccount_index);
         slot.caller_account_metadata = Some(metadata);
         slot.account_view_kind = Some(kind);
         slot.is_writable = is_writable;
@@ -1005,6 +1063,176 @@ declare_builtin_function!(
             out_header_addr,
             memory_mapping,
             AccountViewKind::C,
+        )
+    }
+);
+
+/// Shared body of the read-only `sol_load_subaccount_snapshot_{rust,c}`
+/// syscalls.
+///
+/// Like [`load_subaccount_impl`], but:
+///   - it does **not** require a base account in the transaction — the address
+///     is derived from the seeds alone ([`translate_subaccount_seeds_no_base`]),
+///     because a read-only load never write-locks a base account;
+///   - the slot is always **read-only** (`is_writable == false`), so the data
+///     region is mapped read-only and the entry is never touched/persisted; and
+///   - the on-chain state is read **as of the beginning of the block**
+///     (parent-slot state) via `get_account_shared_data_at_block_start`, then
+///     stored in a fresh, non-deduplicated lane entry
+///     ([`add_readonly_subaccount_snapshot`]) so the snapshot is independent of
+///     any mid-block load of the same subaccount.
+///
+/// The slot is released by the same `sol_unload_subaccount`.
+fn load_subaccount_snapshot_impl(
+    invoke_context: &mut InvokeContext,
+    seeds_addr: u64,
+    seeds_len: u64,
+    out_header_addr: u64,
+    memory_mapping: &mut MemoryMapping,
+) -> Result<u64, Error> {
+    check_subaccount_syscall_enabled(invoke_context, "sol_load_subaccount_snapshot")?;
+
+    let mut load_subaccount_time = Measure::start("load_subaccount");
+    let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+    consume_compute_meter(invoke_context, syscall_base_cost)?;
+    let check_aligned = invoke_context.get_check_aligned();
+
+    let mut compute_subaccounts_time = Measure::start("compute_subaccounts");
+    // Translate seeds → derive PDA. Read-only snapshot loads never require a
+    // base account, so writability is unconditionally false.
+    let snapshot_pubkey = {
+        let instruction_context = invoke_context
+            .transaction_context
+            .get_current_instruction_context()?;
+        let program_id = *instruction_context.get_program_key()?;
+        translate_subaccount_seeds_no_base(
+            &program_id,
+            seeds_addr,
+            seeds_len,
+            memory_mapping,
+            check_aligned,
+        )?
+    };
+    compute_subaccounts_time.stop();
+    invoke_context.timings.compute_subaccounts_us += compute_subaccounts_time.as_us();
+    let is_writable = false;  // snapshot loads are always read-only
+
+    // Load the start-of-block on-chain state and register it in a fresh
+    // non-deduplicated lane entry so it is independent of any mid-block load of
+    // the same subaccount. Snapshot a copy of the header fields for the slot.
+    let (subaccount_index, data_len, lamports, owner_bytes) = {
+        let snapshot_index = find_or_add_subaccount_snapshot(invoke_context, snapshot_pubkey)?;
+        let snapshot = invoke_context
+            .transaction_context
+            .accounts()
+            .get_subaccount_snapshot(snapshot_index)?;
+        let data_len = snapshot.data().len();
+        let lamports = snapshot.lamports();
+        let owner_bytes = *snapshot.owner();
+        (snapshot_index, data_len, lamports, owner_bytes)
+    };
+
+    // Pick a free slot. The index-based "already loaded" guard from
+    // `load_subaccount_impl` is intentionally omitted: each snapshot uses a
+    // fresh index and is read-only, so there is no writable-alias hazard from
+    // loading the same subaccount twice.
+    let (slot_index, vm_header_addr, vm_data_addr) = {
+        let syscall_context = invoke_context.get_syscall_context_mut()?;
+        if syscall_context
+            .subaccount_slots
+            .iter()
+            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Snapshot(subaccount_index))
+        {
+            ic_msg!(
+                invoke_context,
+                "sol_load_subaccount_snapshot: subaccount snapshot {} is already loaded",
+                snapshot_pubkey,
+            );
+            return Err(InstructionError::AccountAlreadyInitialized.into());
+        }
+        let Some((slot_index, slot)) = syscall_context
+            .subaccount_slots
+            .iter_mut()
+            .enumerate()
+            .find(|(_, slot)| slot.occupied_subaccount_index.is_empty())
+        else {
+            ic_msg!(invoke_context, "sol_load_subaccount_snapshot: all slots in use");
+            return Err(InstructionError::MaxAccountsExceeded.into());
+        };
+        (
+            slot_index,
+            slot.vm_header_addr,
+            slot.vm_data_addr,
+        )
+    };
+
+    // Stamp the slot header with the loaded subaccount's metadata.
+    write_subaccount_slot_header(
+        memory_mapping,
+        check_aligned,
+        vm_header_addr,
+        &snapshot_pubkey,
+        &owner_bytes,
+        lamports,
+        data_len,
+        is_writable,
+    )?;
+
+    // Map the slot's data region read-only onto the snapshot storage. Because
+    // `is_writable == false`, the entry is left untouched and never persisted.
+    install_subaccount_data_region(
+        invoke_context,
+        memory_mapping,
+        subaccount_index,
+        vm_data_addr,
+        is_writable,
+    )?;
+
+    let metadata = SerializedAccountMetadata {
+        original_data_len: data_len,
+        vm_key_addr: vm_header_addr.saturating_add(SLOT_HEADER_OFFSET_KEY),
+        vm_owner_addr: vm_header_addr.saturating_add(SLOT_HEADER_OFFSET_OWNER),
+        vm_lamports_addr: vm_header_addr.saturating_add(SLOT_HEADER_OFFSET_LAMPORTS),
+        vm_data_addr,
+    };
+
+    let syscall_context = invoke_context.get_syscall_context_mut()?;
+    let header_out = translate_type_mut::<u64>(memory_mapping, out_header_addr, check_aligned)?;
+
+    if let Some(slot) = syscall_context.subaccount_slots.get_mut(slot_index) {
+        slot.occupied_subaccount_index = OccupiedSubaccountIndex::Snapshot(subaccount_index);
+        slot.caller_account_metadata = Some(metadata);
+        slot.account_view_kind = None; // snapshot loads don't have a program-written view because subaccounts are not changed
+        slot.is_writable = false;
+    }
+    *header_out = vm_header_addr;
+
+    load_subaccount_time.stop();
+    invoke_context.timings.load_subaccounts_us += load_subaccount_time.as_us();
+
+    Ok(SUCCESS)
+}
+
+declare_builtin_function!(
+    /// F10: read-only, base-free, start-of-block load of a subaccount into a
+    /// pre-reserved VM slot. See
+    /// [`load_subaccount_snapshot_impl`] for the shared semantics.
+    SyscallLoadSubaccountSnapshot,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        seeds_addr: u64,
+        seeds_len: u64,
+        out_header_addr: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        load_subaccount_snapshot_impl(
+            invoke_context,
+            seeds_addr,
+            seeds_len,
+            out_header_addr,
+            memory_mapping,
         )
     }
 );
@@ -1126,7 +1354,7 @@ declare_builtin_function!(
                 );
                 return Err(InstructionError::InvalidArgument.into());
             };
-            let Some(idx) = slot.occupied_subaccount_index else {
+            let OccupiedSubaccountIndex::Subaccount(idx) = slot.occupied_subaccount_index else {
                 ic_msg!(
                     invoke_context,
                     "sol_unload_subaccount: slot at {:#x} is not loaded",
@@ -1211,7 +1439,7 @@ declare_builtin_function!(
             .subaccount_slots
             .get_mut(slot_index)
         {
-            slot.occupied_subaccount_index = None;
+            slot.occupied_subaccount_index = OccupiedSubaccountIndex::Empty;
             slot.caller_account_metadata = None;
             slot.account_view_kind = None;
             slot.is_writable = false;

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -1137,10 +1137,11 @@ fn load_snapshot_impl(
     invoke_context.timings.compute_subaccounts_us += compute_subaccounts_time.as_us();
     let is_writable = false;  // snapshot loads are always read-only
 
-    // Load the start-of-block on-chain state and register it in a fresh
-    // non-deduplicated lane entry so it is independent of any mid-block load of
-    // the same subaccount. Snapshot a copy of the header fields for the slot.
-    let (subaccount_index, data_len, lamports, owner_bytes) = {
+    // Load the start-of-block on-chain state into the (deduplicated) snapshot
+    // lane and snapshot a copy of the header fields for the slot. The snapshot
+    // lane is independent of the live subaccount lane, so this is unaffected by
+    // any mid-block load of the same subaccount.
+    let (snapshot_index, data_len, lamports, owner_bytes) = {
         let snapshot_index = find_or_add_snapshot(invoke_context, &snapshot_key)?;
         let snapshot = invoke_context
             .transaction_context
@@ -1152,16 +1153,15 @@ fn load_snapshot_impl(
         (snapshot_index, data_len, lamports, owner_bytes)
     };
 
-    // Pick a free slot. The index-based "already loaded" guard from
-    // `load_subaccount_impl` is intentionally omitted: each snapshot uses a
-    // fresh index and is read-only, so there is no writable-alias hazard from
-    // loading the same subaccount twice.
+    // Reject loading the same snapshot twice in one instruction:
+    // `find_or_add_snapshot` dedups by key, so a repeat load returns the same
+    // snapshot index — refuse if a slot already holds it. Then pick a free slot.
     let (slot_index, vm_header_addr, vm_data_addr) = {
         let syscall_context = invoke_context.get_syscall_context_mut()?;
         if syscall_context
             .subaccount_slots
             .iter()
-            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Snapshot(subaccount_index))
+            .any(|s| s.occupied_subaccount_index == OccupiedSubaccountIndex::Snapshot(snapshot_index))
         {
             ic_msg!(
                 invoke_context,
@@ -1204,7 +1204,7 @@ fn load_snapshot_impl(
     install_snapshot_data_region(
         invoke_context,
         memory_mapping,
-        subaccount_index,
+        snapshot_index,
         vm_data_addr,
     )?;
 
@@ -1220,7 +1220,7 @@ fn load_snapshot_impl(
     let header_out = translate_type_mut::<u64>(memory_mapping, out_header_addr, check_aligned)?;
 
     if let Some(slot) = syscall_context.subaccount_slots.get_mut(slot_index) {
-        slot.occupied_subaccount_index = OccupiedSubaccountIndex::Snapshot(subaccount_index);
+        slot.occupied_subaccount_index = OccupiedSubaccountIndex::Snapshot(snapshot_index);
         slot.caller_account_metadata = Some(metadata);
         slot.account_view_kind = None; // snapshot loads don't have a program-written view because subaccounts are not changed
         slot.is_writable = false;
@@ -1235,7 +1235,7 @@ fn load_snapshot_impl(
 
 declare_builtin_function!(
     /// F10: read-only, base-free, start-of-block load of a subaccount into a
-    /// pre-reserved VM slot. See [`load_subaccount_snapshot_impl`] for the shared semantics.
+    /// pre-reserved VM slot. See [`load_snapshot_impl`] for the shared semantics.
     SyscallLoadSubaccountSnapshot,
     fn rust(
         invoke_context: &mut InvokeContext,
@@ -1271,7 +1271,7 @@ declare_builtin_function!(
 );
 
 declare_builtin_function!(
-    /// F10: read-only, base-free, start-of-block load of a account into a
+    /// F10: read-only, base-free, start-of-block load of an account into a
     /// pre-reserved VM slot. See [`load_snapshot_impl`] for the shared semantics.
     SyscallLoadAccountSnapshot,
     fn rust(

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -116,7 +116,7 @@ fn find_or_add_snapshot(
 ) -> Result<IndexOfAccount, Error> {
     let snapshot_index = if let Some(snapshot_index) = invoke_context
         .transaction_context
-        .find_index_of_snapshot(&snapshot_key)
+        .find_index_of_snapshot(snapshot_key)
     {
         snapshot_index
     } else {
@@ -125,7 +125,7 @@ fn find_or_add_snapshot(
             SnapshotKey::Subaccount(pubkey) => &subaccount_storage_address(pubkey),
         };
         let (snapshot, _slot) = invoke_context
-            .get_account_shared_data_at_block_start(&storage_address)
+            .get_account_shared_data_at_block_start(storage_address)
             .unwrap_or_else(|| (AccountSharedData::default(), 0));
         let data_len_cost = (snapshot.data().len() as u64)
             .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
@@ -556,7 +556,6 @@ fn install_snapshot_data_region(
         .accounts()
         .get_snapshot(snapshot_index)?;
     let new_region = MemoryRegion::new_readonly(snapshot.data(), vm_data_addr);
-    drop(snapshot);
     let (region_index, _) = memory_mapping
         .find_region(vm_data_addr)
         .ok_or(InstructionError::MissingAccount)?;

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -12,7 +12,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
-    crate::transaction_accounts::{AccountRefMut, KeyedAccountSharedData, SnapshotKey, TransactionAccounts},
+    crate::transaction_accounts::{
+        AccountRefMut, KeyedAccountSharedData, SnapshotKey, TransactionAccounts,
+    },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
@@ -293,7 +295,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
         if self.find_index_of_subaccount(&pubkey).is_some() {
             return Err(InstructionError::DuplicateAccountIndex);
         }
-        if (self.accounts.number_of_subaccounts_with_snapshots() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
+        if (self.accounts.number_of_subaccounts_with_snapshots() as usize)
+            >= MAX_SUBACCOUNTS_PER_TRANSACTION
+        {
             return Err(InstructionError::MaxAccountsExceeded);
         }
         Ok(self.accounts.add_subaccount(pubkey, account))
@@ -309,12 +313,12 @@ impl<'ix_data> TransactionContext<'ix_data> {
         snapshot_key: &SnapshotKey,
         account: AccountSharedData,
     ) -> Result<IndexOfAccount, InstructionError> {
-        if (self.accounts.number_of_subaccounts_with_snapshots() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
+        if (self.accounts.number_of_subaccounts_with_snapshots() as usize)
+            >= MAX_SUBACCOUNTS_PER_TRANSACTION
+        {
             return Err(InstructionError::MaxAccountsExceeded);
         }
-        Ok(self
-            .accounts
-            .add_snapshot(snapshot_key, account))
+        Ok(self.accounts.add_snapshot(snapshot_key, account))
     }
 
     /// Gets the max length of the instruction trace

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -313,6 +313,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
         snapshot_key: &SnapshotKey,
         account: AccountSharedData,
     ) -> Result<IndexOfAccount, InstructionError> {
+        if self.find_index_of_snapshot(snapshot_key).is_some() {
+            return Err(InstructionError::DuplicateAccountIndex);
+        }
         if (self.accounts.number_of_subaccounts_with_snapshots() as usize)
             >= MAX_SUBACCOUNTS_PER_TRANSACTION
         {

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
-    crate::transaction_accounts::{AccountRefMut, KeyedAccountSharedData, TransactionAccounts},
+    crate::transaction_accounts::{AccountRefMut, KeyedAccountSharedData, SnapshotKey, TransactionAccounts},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
@@ -273,8 +273,8 @@ impl<'ix_data> TransactionContext<'ix_data> {
     }
 
     #[cfg(not(target_os = "solana"))]
-    pub fn find_index_of_snapshot(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
-        self.accounts.find_index_of_snapshot(pubkey)
+    pub fn find_index_of_snapshot(&self, snapshot_key: &SnapshotKey) -> Option<IndexOfAccount> {
+        self.accounts.find_index_of_snapshot(snapshot_key)
     }
 
     /// F10: register a new subaccount under the given key.
@@ -304,9 +304,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
     /// Returns the subaccount index (without the `SUBACCOUNT_MARKER`
     /// high-bit). The entry is left untouched and is never persisted.
     #[cfg(not(target_os = "solana"))]
-    pub fn add_subaccount_snapshot(
+    pub fn add_snapshot(
         &self,
-        pubkey: Pubkey,
+        snapshot_key: &SnapshotKey,
         account: AccountSharedData,
     ) -> Result<IndexOfAccount, InstructionError> {
         if (self.accounts.number_of_subaccounts_with_snapshots() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
@@ -314,7 +314,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         }
         Ok(self
             .accounts
-            .add_subaccount_snapshot(pubkey, account))
+            .add_snapshot(snapshot_key, account))
     }
 
     /// Gets the max length of the instruction trace

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -272,6 +272,11 @@ impl<'ix_data> TransactionContext<'ix_data> {
         self.accounts.find_index_of_subaccount(pubkey)
     }
 
+    #[cfg(not(target_os = "solana"))]
+    pub fn find_index_of_snapshot(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
+        self.accounts.find_index_of_snapshot(pubkey)
+    }
+
     /// F10: register a new subaccount under the given key.
     /// Returns the subaccount index (without the `SUBACCOUNT_MARKER` high-bit).
     ///
@@ -288,10 +293,28 @@ impl<'ix_data> TransactionContext<'ix_data> {
         if self.find_index_of_subaccount(&pubkey).is_some() {
             return Err(InstructionError::DuplicateAccountIndex);
         }
-        if (self.accounts.number_of_subaccounts() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
+        if (self.accounts.number_of_subaccounts_with_snapshots() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
             return Err(InstructionError::MaxAccountsExceeded);
         }
         Ok(self.accounts.add_subaccount(pubkey, account))
+    }
+
+    /// F10: register a read-only block-start snapshot of a subaccount.
+    ///
+    /// Returns the subaccount index (without the `SUBACCOUNT_MARKER`
+    /// high-bit). The entry is left untouched and is never persisted.
+    #[cfg(not(target_os = "solana"))]
+    pub fn add_subaccount_snapshot(
+        &self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> Result<IndexOfAccount, InstructionError> {
+        if (self.accounts.number_of_subaccounts_with_snapshots() as usize) >= MAX_SUBACCOUNTS_PER_TRANSACTION {
+            return Err(InstructionError::MaxAccountsExceeded);
+        }
+        Ok(self
+            .accounts
+            .add_subaccount_snapshot(pubkey, account))
     }
 
     /// Gets the max length of the instruction trace

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -677,8 +677,8 @@ impl TransactionAccounts {
         ),
         InstructionError,
     > {
-        let shared = self.subaccount_shared_fields.borrow();
-        let private = self.subaccount_private_fields.borrow();
+        let shared = self.snapshot_shared_fields.borrow();
+        let private = self.snapshot_private_fields.borrow();
         let shared_box = shared
             .get(index as usize)
             .ok_or(InstructionError::MissingAccount)?;

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -441,16 +441,15 @@ impl TransactionAccounts {
         index
     }
 
-    /// F10: append a new subaccount snapshot into the split-storage lane. 
-    /// Populates the two parallel Vecs (shared fields, private fields) 
-    /// without borrow counters and touched flags. Caller is responsible 
-    /// for deduplication — `TransactionContext::add_subaccount_snapshot` does the
+    /// F10: append a new subaccount snapshot into the split-storage lane.
+    /// Populates the two parallel Vecs (shared fields, private fields)
+    /// without borrow counters and touched flags. Caller is responsible
+    /// for deduplication — `TransactionContext::add_snapshot` does the
     /// find-index check before this.
     ///
     /// The entry is left **untouched**, so the end-of-tx dirty filter never
     /// persists it.
     #[cfg(not(target_os = "solana"))]
-    #[allow(dead_code)] // wired in by the snapshot syscall
     pub(crate) fn add_snapshot(
         &self,
         snapshot_key: &SnapshotKey,
@@ -526,17 +525,6 @@ impl TransactionAccounts {
         let indexes = self.snapshot_indexes.borrow();
         indexes.get(snapshot_key).copied()
     }
-
-    #[cfg(not(target_os = "solana"))]
-    pub fn snapshot_key(&self, index: IndexOfAccount) -> Option<Pubkey> {
-        let shared = self.snapshot_shared_fields.borrow();
-        // SAFETY: `key` is set at construction and never mutated; immutable
-        // read is safe regardless of outstanding AccountRef/AccountRefMut.
-        shared
-            .get(index as usize)
-            .map(|boxed| unsafe { (*boxed.get()).key })
-    }
-
 
     #[cfg(not(target_os = "solana"))]
     pub fn subaccount_key(&self, index: IndexOfAccount) -> Option<Pubkey> {

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -245,6 +245,21 @@ pub(crate) type DeconstructedTransactionAccounts = (
     Cell<i64>,
 );
 
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+pub enum SnapshotKey {
+    Account(Pubkey),
+    Subaccount(Pubkey),
+}
+
+impl SnapshotKey {
+    pub fn as_pubkey(&self) -> &Pubkey {
+        match self {
+            SnapshotKey::Account(key) => key,
+            SnapshotKey::Subaccount(key) => key,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct TransactionAccounts {
     shared_account_fields: Box<[UnsafeCell<AccountSharedFields>]>,
@@ -300,7 +315,7 @@ pub struct TransactionAccounts {
     #[allow(clippy::vec_box)]
     snapshot_private_fields: RefCell<Vec<Box<UnsafeCell<AccountPrivateFields>>>>,
     #[cfg(not(target_os = "solana"))]
-    snapshot_indexes: RefCell<HashMap<Pubkey, IndexOfAccount>>,
+    snapshot_indexes: RefCell<HashMap<SnapshotKey, IndexOfAccount>>,
 }
 
 impl TransactionAccounts {
@@ -436,9 +451,9 @@ impl TransactionAccounts {
     /// persists it.
     #[cfg(not(target_os = "solana"))]
     #[allow(dead_code)] // wired in by the snapshot syscall
-    pub(crate) fn add_subaccount_snapshot(
+    pub(crate) fn add_snapshot(
         &self,
-        pubkey: Pubkey,
+        snapshot_key: &SnapshotKey,
         account: AccountSharedData,
     ) -> IndexOfAccount {
         let lamports = account.lamports();
@@ -447,7 +462,7 @@ impl TransactionAccounts {
         let mut indexes = self.snapshot_indexes.borrow_mut();
         let index = shared.len() as IndexOfAccount;
         shared.push(Box::new(UnsafeCell::new(AccountSharedFields {
-            key: pubkey,
+            key: *snapshot_key.as_pubkey(),
             owner: *account.owner(),
             lamports,
             payload: crate::vm_slice::VmSlice::new(0, account.data().len() as u64),
@@ -458,7 +473,7 @@ impl TransactionAccounts {
             payload: account.data_clone(),
         })));
         // Intentionally doesn't track lamports in `dynamic_accounts_lamports_sum` — the snapshot is read-only
-        indexes.insert(pubkey, index);
+        indexes.insert(snapshot_key.clone(), index);
         index
     }
 
@@ -508,9 +523,9 @@ impl TransactionAccounts {
     }
 
     #[cfg(not(target_os = "solana"))]
-    pub fn find_index_of_snapshot(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
+    pub fn find_index_of_snapshot(&self, snapshot_key: &SnapshotKey) -> Option<IndexOfAccount> {
         let indexes = self.snapshot_indexes.borrow();
-        indexes.get(pubkey).copied()
+        indexes.get(snapshot_key).copied()
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -629,7 +644,7 @@ impl TransactionAccounts {
     /// to access the state of a subaccount at a specific point in time, 
     /// without allowing any modifications.
     #[cfg(not(target_os = "solana"))]
-    pub fn get_subaccount_snapshot(
+    pub fn get_snapshot(
         &self,
         index: IndexOfAccount,
     ) -> Result<TransactionAccountView<'_>, InstructionError> {

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -638,9 +638,9 @@ impl TransactionAccounts {
         let (shared_ptr, private_ptr) = self.snapshot_raw_ptrs(index)?;
 
         // SAFETY: pointers obtained from `Box<_>`-owned entries in append-only
-        // Vecs — heap addresses are stable for the life of `self`. The borrow
-        // counter below guarantees no live `AccountRefMut` exists for this
-        // slot.
+        // Vecs — heap addresses are stable for the life of `self`. Snapshots are
+         // only exposed through shared views, so safe code cannot obtain `&mut`
+         // access to these cells.
         let abi_account = unsafe { &*(*shared_ptr).get() };
         let private_fields = unsafe { &*(*private_ptr).get() };
         Ok(TransactionAccountView {

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -627,8 +627,8 @@ impl TransactionAccounts {
         Ok((shared_ptr, private_ptr, counter_ptr))
     }
 
-    /// Return subaccount snapshot view for the given index. This is used 
-    /// to access the state of a subaccount at a specific point in time, 
+    /// Return subaccount snapshot view for the given index. This is used
+    /// to access the state of a subaccount at a specific point in time,
     /// without allowing any modifications.
     #[cfg(not(target_os = "solana"))]
     pub fn get_snapshot(
@@ -858,8 +858,10 @@ impl TransactionAccounts {
         let sub_private = std::mem::take(&mut *self.subaccount_private_fields.borrow_mut());
         let sub_touched = std::mem::take(&mut *self.touched_subaccounts.borrow_mut());
         let mut unchanged_subaccounts: Vec<Pubkey> = Vec::new();
-        for (idx, (shared_box, private_box)) in
-            sub_shared.into_iter().zip(sub_private.into_iter()).enumerate()
+        for (idx, (shared_box, private_box)) in sub_shared
+            .into_iter()
+            .zip(sub_private.into_iter())
+            .enumerate()
         {
             let shared = (*shared_box).into_inner();
             // F10: only persist subaccounts that were actually modified this
@@ -918,8 +920,10 @@ impl TransactionAccounts {
         let sub_shared = std::mem::take(&mut *self.subaccount_shared_fields.borrow_mut());
         let sub_private = std::mem::take(&mut *self.subaccount_private_fields.borrow_mut());
         let sub_touched = std::mem::take(&mut *self.touched_subaccounts.borrow_mut());
-        for (idx, (shared_box, private_box)) in
-            sub_shared.into_iter().zip(sub_private.into_iter()).enumerate()
+        for (idx, (shared_box, private_box)) in sub_shared
+            .into_iter()
+            .zip(sub_private.into_iter())
+            .enumerate()
         {
             // F10: skip subaccounts that were never modified — see the keyed
             // variant `deconstruct_into_keyed_account_shared_data` for the
@@ -1464,7 +1468,10 @@ mod tests {
         // `subaccount_storage_address` is applied later at the accounts-db
         // boundary.
         let (sub_key, sub_account) = accounts.get(1).unwrap();
-        assert_eq!(*sub_key, touched_pda, "touched subaccount persisted by owner key");
+        assert_eq!(
+            *sub_key, touched_pda,
+            "touched subaccount persisted by owner key"
+        );
         assert_eq!(sub_account.lamports(), 1_000);
         // The untouched sibling is not persisted, but is reported to the
         // receipt as an unchanged subaccount (owner key only).

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -292,6 +292,15 @@ pub struct TransactionAccounts {
     touched_subaccounts: RefCell<Vec<bool>>,
     #[cfg(not(target_os = "solana"))]
     subaccount_indexes: RefCell<HashMap<Pubkey, IndexOfAccount>>,
+
+    #[cfg(not(target_os = "solana"))]
+    #[allow(clippy::vec_box)]
+    snapshot_shared_fields: RefCell<Vec<Box<UnsafeCell<AccountSharedFields>>>>,
+    #[cfg(not(target_os = "solana"))]
+    #[allow(clippy::vec_box)]
+    snapshot_private_fields: RefCell<Vec<Box<UnsafeCell<AccountPrivateFields>>>>,
+    #[cfg(not(target_os = "solana"))]
+    snapshot_indexes: RefCell<HashMap<Pubkey, IndexOfAccount>>,
 }
 
 impl TransactionAccounts {
@@ -338,6 +347,11 @@ impl TransactionAccounts {
             subaccount_borrow_counters: RefCell::new(Vec::new()),
             touched_subaccounts: RefCell::new(Vec::new()),
             subaccount_indexes: RefCell::new(HashMap::new()),
+
+            snapshot_shared_fields: RefCell::new(Vec::new()),
+            snapshot_private_fields: RefCell::new(Vec::new()),
+            snapshot_indexes: RefCell::new(HashMap::new()),
+
             dynamic_accounts_lamports_sum: Cell::new(0),
         }
     }
@@ -412,6 +426,42 @@ impl TransactionAccounts {
         index
     }
 
+    /// F10: append a new subaccount snapshot into the split-storage lane. 
+    /// Populates the two parallel Vecs (shared fields, private fields) 
+    /// without borrow counters and touched flags. Caller is responsible 
+    /// for deduplication — `TransactionContext::add_subaccount_snapshot` does the
+    /// find-index check before this.
+    ///
+    /// The entry is left **untouched**, so the end-of-tx dirty filter never
+    /// persists it.
+    #[cfg(not(target_os = "solana"))]
+    #[allow(dead_code)] // wired in by the snapshot syscall
+    pub(crate) fn add_subaccount_snapshot(
+        &self,
+        pubkey: Pubkey,
+        account: AccountSharedData,
+    ) -> IndexOfAccount {
+        let lamports = account.lamports();
+        let mut shared = self.snapshot_shared_fields.borrow_mut();
+        let mut private = self.snapshot_private_fields.borrow_mut();
+        let mut indexes = self.snapshot_indexes.borrow_mut();
+        let index = shared.len() as IndexOfAccount;
+        shared.push(Box::new(UnsafeCell::new(AccountSharedFields {
+            key: pubkey,
+            owner: *account.owner(),
+            lamports,
+            payload: crate::vm_slice::VmSlice::new(0, account.data().len() as u64),
+        })));
+        private.push(Box::new(UnsafeCell::new(AccountPrivateFields {
+            rent_epoch: account.rent_epoch(),
+            executable: account.executable(),
+            payload: account.data_clone(),
+        })));
+        // Intentionally doesn't track lamports in `dynamic_accounts_lamports_sum` — the snapshot is read-only
+        indexes.insert(pubkey, index);
+        index
+    }
+
     /// F10 W10: lamports introduced by `add_subaccount` for accounts not
     /// present in the original tx account list. SVM/runtime callers add
     /// this to the expected post-tx lamport sum to avoid false
@@ -444,8 +494,11 @@ impl TransactionAccounts {
     }
 
     #[cfg(not(target_os = "solana"))]
-    pub fn number_of_subaccounts(&self) -> IndexOfAccount {
-        self.subaccount_shared_fields.borrow().len() as IndexOfAccount
+    pub fn number_of_subaccounts_with_snapshots(&self) -> IndexOfAccount {
+        (
+            self.subaccount_shared_fields.borrow().len()
+            + self.snapshot_shared_fields.borrow().len()
+        ) as IndexOfAccount
     }
 
     #[cfg(not(target_os = "solana"))]
@@ -453,6 +506,23 @@ impl TransactionAccounts {
         let indexes = self.subaccount_indexes.borrow();
         indexes.get(pubkey).copied()
     }
+
+    #[cfg(not(target_os = "solana"))]
+    pub fn find_index_of_snapshot(&self, pubkey: &Pubkey) -> Option<IndexOfAccount> {
+        let indexes = self.snapshot_indexes.borrow();
+        indexes.get(pubkey).copied()
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    pub fn snapshot_key(&self, index: IndexOfAccount) -> Option<Pubkey> {
+        let shared = self.snapshot_shared_fields.borrow();
+        // SAFETY: `key` is set at construction and never mutated; immutable
+        // read is safe regardless of outstanding AccountRef/AccountRefMut.
+        shared
+            .get(index as usize)
+            .map(|boxed| unsafe { (*boxed.get()).key })
+    }
+
 
     #[cfg(not(target_os = "solana"))]
     pub fn subaccount_key(&self, index: IndexOfAccount) -> Option<Pubkey> {
@@ -553,6 +623,57 @@ impl TransactionAccounts {
             &**private_box as *const _ as *mut _;
         let counter_ptr: *const BorrowCounter = &**counter_box;
         Ok((shared_ptr, private_ptr, counter_ptr))
+    }
+
+    /// Return subaccount snapshot view for the given index. This is used 
+    /// to access the state of a subaccount at a specific point in time, 
+    /// without allowing any modifications.
+    #[cfg(not(target_os = "solana"))]
+    pub fn get_subaccount_snapshot(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<TransactionAccountView<'_>, InstructionError> {
+        let (shared_ptr, private_ptr) = self.snapshot_raw_ptrs(index)?;
+
+        // SAFETY: pointers obtained from `Box<_>`-owned entries in append-only
+        // Vecs — heap addresses are stable for the life of `self`. The borrow
+        // counter below guarantees no live `AccountRefMut` exists for this
+        // slot.
+        let abi_account = unsafe { &*(*shared_ptr).get() };
+        let private_fields = unsafe { &*(*private_ptr).get() };
+        Ok(TransactionAccountView {
+            abi_account,
+            private_fields,
+        })
+    }
+
+    /// Extracts stable raw pointers to the two split-storage cells of the
+    /// subaccount snapshot at `index`. The RefCell borrows on the outer Vecs are
+    /// dropped before returning because the Box-owned heap addresses are
+    /// stable for the life of `self` (append-only invariant).
+    #[cfg(not(target_os = "solana"))]
+    fn snapshot_raw_ptrs(
+        &self,
+        index: IndexOfAccount,
+    ) -> Result<
+        (
+            *mut UnsafeCell<AccountSharedFields>,
+            *mut UnsafeCell<AccountPrivateFields>,
+        ),
+        InstructionError,
+    > {
+        let shared = self.subaccount_shared_fields.borrow();
+        let private = self.subaccount_private_fields.borrow();
+        let shared_box = shared
+            .get(index as usize)
+            .ok_or(InstructionError::MissingAccount)?;
+        let private_box = private
+            .get(index as usize)
+            .ok_or(InstructionError::MissingAccount)?;
+        let shared_ptr: *mut UnsafeCell<AccountSharedFields> = &**shared_box as *const _ as *mut _;
+        let private_ptr: *mut UnsafeCell<AccountPrivateFields> =
+            &**private_box as *const _ as *mut _;
+        Ok((shared_ptr, private_ptr))
     }
 
     pub(crate) fn update_accounts_resize_delta(
@@ -1112,7 +1233,7 @@ mod tests {
     #[test]
     fn test_add_subaccount_populates_split_storage() {
         let tx_accounts = make_tx_accounts();
-        assert_eq!(tx_accounts.number_of_subaccounts(), 0);
+        assert_eq!(tx_accounts.number_of_subaccounts_with_snapshots(), 0);
 
         let sub_key = Pubkey::new_unique();
         let sub_owner = Pubkey::new_unique();
@@ -1120,7 +1241,7 @@ mod tests {
         let index = tx_accounts.add_subaccount(sub_key, sub_account);
 
         assert_eq!(index, 0);
-        assert_eq!(tx_accounts.number_of_subaccounts(), 1);
+        assert_eq!(tx_accounts.number_of_subaccounts_with_snapshots(), 1);
         assert_eq!(tx_accounts.find_index_of_subaccount(&sub_key), Some(0));
         assert_eq!(tx_accounts.subaccount_key(0), Some(sub_key));
         assert_eq!(

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -510,10 +510,9 @@ impl TransactionAccounts {
 
     #[cfg(not(target_os = "solana"))]
     pub fn number_of_subaccounts_with_snapshots(&self) -> IndexOfAccount {
-        (
-            self.subaccount_shared_fields.borrow().len()
-            + self.snapshot_shared_fields.borrow().len()
-        ) as IndexOfAccount
+        let subaccount_len = self.subaccount_shared_fields.borrow().len();
+        let snapshot_len = self.snapshot_shared_fields.borrow().len();
+        subaccount_len.saturating_add(snapshot_len) as IndexOfAccount
     }
 
     #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Summary of Changes
- Implement `load_subaccount_snapshot` syscall for read subaccount snapshot at the start of the block
- Implement `load_account_snapshot` syscall for read account snapshot at the start of the block
- Add tests for these syscalls