### PR TITLE
Add git commit to getVersion rpc call

### DIFF
--- a/rpc-client-types/src/response.rs
+++ b/rpc-client-types/src/response.rs
@@ -348,6 +348,9 @@ pub struct RpcVersionInfo {
     pub solana_core: String,
     /// first 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
+    /// The full git commit hash that solana-core was built from
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
 }
 
 impl fmt::Debug for RpcVersionInfo {

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -372,6 +372,7 @@ impl RpcSender for MockSender {
                 json!(RpcVersionInfo {
                     solana_core: version.to_string(),
                     feature_set: Some(version.feature_set),
+                    git_commit: solana_version::git_commit_hash().map(String::from),
                 })
             }
             "getLatestBlockhash" => serde_json::to_value(Response {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2923,6 +2923,7 @@ pub mod rpc_minimal {
             Ok(RpcVersionInfo {
                 solana_core: version.to_string(),
                 feature_set: Some(version.feature_set),
+                git_commit: solana_version::git_commit_hash().map(String::from),
             })
         }
 

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -606,6 +606,7 @@ impl RpcSolPubSubInternal for RpcSolPubSubImpl {
         Ok(RpcVersionInfo {
             solana_core: version.to_string(),
             feature_set: Some(version.feature_set),
+            git_commit: solana_version::git_commit_hash().map(String::from),
         })
     }
 }

--- a/version/build.rs
+++ b/version/build.rs
@@ -9,4 +9,22 @@ fn main() {
             }
         }
     }
+
+    // Re-run this build script (and therefore re-stamp the commit hash) whenever
+    // the checked-out commit changes. `.git/HEAD` changes on branch switch and
+    // its target ref file changes on new commits; `.git/packed-refs` covers the
+    // packed case. Paths are relative to this crate's manifest directory.
+    if let Ok(git_dir_output) = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+    {
+        if git_dir_output.status.success() {
+            if let Ok(git_dir) = String::from_utf8(git_dir_output.stdout) {
+                let git_dir = git_dir.trim();
+                println!("cargo:rerun-if-changed={git_dir}/HEAD");
+                println!("cargo:rerun-if-changed={git_dir}/packed-refs");
+                println!("cargo:rerun-if-changed={git_dir}/refs");
+            }
+        }
+    }
 }

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -63,6 +63,15 @@ fn compute_commit(sha1: Option<&'static str>) -> Option<u32> {
     u32::from_str_radix(sha1?.get(..8)?, /*radix:*/ 16).ok()
 }
 
+/// Returns the full git commit hash that this binary was built from, if it was
+/// captured at build time (see `build.rs`). `None` when building outside of a
+/// git checkout.
+pub fn git_commit_hash() -> Option<&'static str> {
+    option_env!("CI_COMMIT")
+        .or(option_env!("AGAVE_GIT_COMMIT_HASH"))
+        .filter(|hash| !hash.is_empty())
+}
+
 impl Default for Version {
     fn default() -> Self {
         let feature_set =


### PR DESCRIPTION
Add an optional `git-commit` field to `RpcVersionInfo` carrying the full sha1 of the commit the node was built from. The hash is already captured at build time in `version/build.rs` (AGAVE_GIT_COMMIT_HASH); expose it via a new `solana_version::git_commit_hash()` helper and populate the field in the getVersion handlers (rpc, rpc_pubsub) and the mock sender.

The field is skipped when serializing if absent, so existing clients and the previous response shape are unaffected.

Also add `rerun-if-changed` directives to `version/build.rs` so the captured commit hash is refreshed when HEAD moves.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
