### PR TITLE
Prs 453 fix subaccounts feature

### DIFF
--- a/ci/parasol-node-run.sh
+++ b/ci/parasol-node-run.sh
@@ -1,20 +1,4 @@
 #!/bin/sh
-# F10 subaccounts require two v4 ABI features deactivated (space-separated
-# pubkeys, one --deactivate-feature each):
-#   ptr9umik… direct_account_pointers_in_program_input — mutually exclusive with
-#     the subaccount slot region; active → runtime reserves 0 slots, parasol-dex
-#     sol_load_subaccount fails with MaxAccountsExceeded.
-#   EDGMC5…  syscall_parameter_address_restrictions — rejects the subaccount
-#     AccountInfo pointers F10 places in the input region during CPI; active →
-#     deposit fails with "Invalid pointer".
-# (account_data_direct_mapping / virtual_address_space_adjustments must stay
-# ACTIVE — deactivating them breaks the v4 VM memory-region layout.)
-DEACTIVATE_FEATURES="${DEACTIVATE_FEATURES:-ptr9umikaeAS7ZBBp2fsfRhie16F1V2jCKA2y6gXNAK EDGMC5kxFxGk4ixsNkGt8bW7QL5hDMXnbwaZvYMwNfzF}"
-DEACTIVATE_FLAGS=""
-for f in ${DEACTIVATE_FEATURES}; do
-  [ -n "${f}" ] && DEACTIVATE_FLAGS="${DEACTIVATE_FLAGS} --deactivate-feature ${f}"
-done
-
 solana-test-validator \
   --ticks-per-slot 16 \
   --ledger /opt/parasol/data \
@@ -22,5 +6,4 @@ solana-test-validator \
   --faucet-port 19900 \
   --gossip-port 18000 \
   --limit-ledger-size 1000000 \
-  ${DEACTIVATE_FLAGS} \
   --log

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -307,8 +307,10 @@ impl<'a> CallerAccount<'a> {
         _vm_addr: u64,
         account_info: &solana_account_info::AccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
+        enable_mm_input: bool,
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::{translate_type, translate_type_mut_for_cpi};
+        let max_ptr_value = solana_sbpf::ebpf::MM_INPUT_START + if enable_mm_input {solana_sbpf::ebpf::MM_REGION_SIZE} else {0};
 
         let syscall_parameter_address_restrictions = invoke_context
             .get_feature_set()
@@ -344,7 +346,7 @@ impl<'a> CallerAccount<'a> {
                 check_aligned,
             )?;
             if syscall_parameter_address_restrictions {
-                if account_info.lamports.as_ptr() as u64 >= solana_sbpf::ebpf::MM_INPUT_START {
+                if account_info.lamports.as_ptr() as u64 >= max_ptr_value {
                     return Err(Box::new(CpiError::InvalidPointer));
                 }
 
@@ -366,7 +368,7 @@ impl<'a> CallerAccount<'a> {
 
         let (serialized_data, vm_data_addr, ref_to_len_in_vm) = {
             if syscall_parameter_address_restrictions
-                && account_info.data.as_ptr() as u64 >= solana_sbpf::ebpf::MM_INPUT_START
+                && account_info.data.as_ptr() as u64 >= max_ptr_value
             {
                 return Err(Box::new(CpiError::InvalidPointer));
             }
@@ -399,7 +401,7 @@ impl<'a> CallerAccount<'a> {
                 // In the same vein as the other check_account_info_pointer() checks, we don't lock
                 // this pointer to a specific address but we don't want it to be inside accounts, or
                 // callees might be able to write to the pointed memory.
-                if vm_len_addr >= solana_sbpf::ebpf::MM_INPUT_START {
+                if vm_len_addr >= max_ptr_value {
                     return Err(Box::new(CpiError::InvalidPointer));
                 }
             }
@@ -441,8 +443,10 @@ impl<'a> CallerAccount<'a> {
         vm_addr: u64,
         account_info: &SolAccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
+        enable_mm_input: bool,
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::translate_type_mut_for_cpi;
+        let max_ptr_value = solana_sbpf::ebpf::MM_INPUT_START + if enable_mm_input {solana_sbpf::ebpf::MM_REGION_SIZE} else {0};
 
         let syscall_parameter_address_restrictions = invoke_context
             .get_feature_set()
@@ -517,7 +521,7 @@ impl<'a> CallerAccount<'a> {
             // In the same vein as the other check_account_info_pointer() checks, we don't lock
             // this pointer to a specific address but we don't want it to be inside accounts, or
             // callees might be able to write to the pointed memory.
-            if vm_len_addr >= solana_sbpf::ebpf::MM_INPUT_START {
+            if vm_len_addr >= max_ptr_value {
                 return Err(Box::new(CpiError::InvalidPointer));
             }
         }
@@ -1100,6 +1104,7 @@ where
         u64,
         &T,
         &SerializedAccountMetadata,
+        bool,
     ) -> Result<CallerAccount<'a>, Error>,
 {
     let transaction_context = &invoke_context.transaction_context;
@@ -1179,6 +1184,7 @@ where
                     ),
                     &account_infos[caller_account_index],
                     serialized_metadata,
+                    false,
                 )?;
 
             if syscall_parameter_address_restrictions {
@@ -1305,6 +1311,7 @@ pub fn translate_subaccount_slots<'a>(
                     view_addr,
                     view,
                     &metadata,
+                    true,
                 )?
             }
             crate::invoke_context::AccountViewKind::C => {
@@ -1317,6 +1324,7 @@ pub fn translate_subaccount_slots<'a>(
                     view_addr,
                     view,
                     &metadata,
+                    true,
                 )?
             }
         };

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -2157,6 +2157,8 @@ mod tests {
             .set_syscall_context(SyscallContext {
                 allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 accounts_metadata: vec![account_metadata],
+                subaccount_slots: Vec::new(),
+                trace_log: Vec::new(),
             })
             .unwrap();
 
@@ -2254,6 +2256,7 @@ mod tests {
             vm_addr,
             account_info,
             &account_metadata,
+            false,
         )
         .unwrap();
         assert_eq!(*caller_account.lamports, account.lamports());

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -632,28 +632,27 @@ fn serialize_parameters_for_abiv1(
     }
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>(); // program id;
+    + size_of::<Pubkey>() // program id
+    // F10: alignment padding so the u64 subaccount count lands on BPF_ALIGN_OF_U128
+    // boundary, matching parasol-dev PRS-153 layout.
+    + (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
 
     // reserve space for account pointer array if SIMD-0449 is enabled
-    let account_pointers_offset = if direct_account_pointers_program_input {
-        let offset = (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
-        size += offset + accounts.len() * size_of::<u64>();
-        Some(offset)
-    } else {
-        // F10 (SIMD-0449 mutual-gate): when direct account pointers are NOT
-        // active, reserve the subaccount slot region in the same post-program_id
-        // byte range the pointer array would occupy. The two are mutually
-        // exclusive by construction — `sol_load_subaccount` is gated off whenever
-        // SIMD-0449 is active — so they never collide. In the direct-map model no
-        // real-subaccount records are serialized (data is direct-mapped); only the
-        // MAX_SUBACCOUNT_SLOTS reserved slots (each an account-view buffer + the
-        // 88-byte header) are laid out, after alignment padding.
-        size += (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
-        size += MAX_SUBACCOUNT_SLOTS.saturating_mul(
-            SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE.saturating_add(SUBACCOUNT_SLOT_HEADER_SIZE),
-        );
-        None
+    if direct_account_pointers_program_input {
+        size += accounts.len() * size_of::<u64>();
     };
+
+    // F10 (SIMD-0449 mutual-gate): when direct account pointers are NOT
+    // active, reserve the subaccount slot region in the same post-program_id
+    // byte range the pointer array would occupy. The two are mutually
+    // exclusive by construction — `sol_load_subaccount` is gated off whenever
+    // SIMD-0449 is active — so they never collide. In the direct-map model no
+    // real-subaccount records are serialized (data is direct-mapped); only the
+    // MAX_SUBACCOUNT_SLOTS reserved slots (each an account-view buffer + the
+    // 88-byte header) are laid out, after alignment padding.
+    size += MAX_SUBACCOUNT_SLOTS.saturating_mul(
+        SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE.saturating_add(SUBACCOUNT_SLOT_HEADER_SIZE),
+    );
 
     let mut s = Serializer::new(
         size,
@@ -700,82 +699,72 @@ fn serialize_parameters_for_abiv1(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     let instruction_data_offset = s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
+    let align_offset = (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    s.fill_write(align_offset, 0)
+        .map_err(|_| InstructionError::InvalidArgument)?;
 
-    let mut subaccount_slots: Vec<SubaccountSlot> = Vec::new();
-    if let Some(offset) = account_pointers_offset {
-        // Add padding before the account pointer array to reach 8-byte alignment
-        // (BPF_ALIGN_OF_U128). SIMD-0449 branch: no subaccount region is written.
-        s.fill_write(offset, 0)
-            .map_err(|_| InstructionError::InvalidArgument)?;
+    if direct_account_pointers_program_input {
         for entry in accounts_metadata.iter() {
             s.write::<u64>(entry.vm_addr.to_le());
         }
-    } else {
-        // F10 (SIMD-0449 mutual-gate else): write the subaccount slot region.
-        // Alignment padding so the reserved slots land on a BPF_ALIGN_OF_U128
-        // boundary. No real-subaccount records are written — subaccount data is
-        // direct-mapped, so only the MAX_SUBACCOUNT_SLOTS reserved slots follow.
-        let align_offset = (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
-        s.fill_write(align_offset, 0)
-            .map_err(|_| InstructionError::InvalidArgument)?;
+    }
 
-        // F10: reserve MAX_SUBACCOUNT_SLOTS slots. Each slot consists of two
-        // memory regions:
-        //   1. a writable region inside the input buffer holding a runtime-owned
-        //      account-view buffer (SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE bytes,
-        //      used by the program as either `AccountInfo` or `SolAccountInfo`)
-        //      immediately followed by the 88-byte serialized slot header
-        //      (NON_DUP_MARKER + flags + key + owner + lamports + data_len),
-        //   2. an empty readonly placeholder data region whose VM address is
-        //      reserved with SUBACCOUNT_SLOT_DATA_RESERVED_VM_BYTES so a later
-        //      MemoryMapping::replace_region can install a region backed by the
-        //      loaded subaccount's AccountSharedData without colliding with the
-        //      next slot's reserved range.
-        // Close any preceding region first so each slot's view-buffer + header
-        // pair lives in its own region.
+    // F10: reserve MAX_SUBACCOUNT_SLOTS slots. Each slot consists of two
+    // memory regions:
+    //   1. a writable region inside the input buffer holding a runtime-owned
+    //      account-view buffer (SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE bytes,
+    //      used by the program as either `AccountInfo` or `SolAccountInfo`)
+    //      immediately followed by the 88-byte serialized slot header
+    //      (NON_DUP_MARKER + flags + key + owner + lamports + data_len),
+    //   2. an empty readonly placeholder data region whose VM address is
+    //      reserved with SUBACCOUNT_SLOT_DATA_RESERVED_VM_BYTES so a later
+    //      MemoryMapping::replace_region can install a region backed by the
+    //      loaded subaccount's AccountSharedData without colliding with the
+    //      next slot's reserved range.
+    // Close any preceding region first so each slot's view-buffer + header
+    // pair lives in its own region.
+    s.push_region();
+    let mut subaccount_slots = Vec::with_capacity(MAX_SUBACCOUNT_SLOTS);
+    for _ in 0..MAX_SUBACCOUNT_SLOTS {
+        // Runtime-owned account-view buffer: the program writes its
+        // `AccountInfo` / `SolAccountInfo` here after `sol_load_subaccount`
+        // returns the address. Zero-initialized so the program observes a
+        // clean slate per slot.
+        let vm_account_view_addr = s.current_vaddr();
+        s.fill_write(SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE, 0)
+            .map_err(|_| InstructionError::InvalidArgument)?;
+        let vm_header_addr = s.current_vaddr();
+        let buffer_position = s.current_len();
+        s.write::<u8>(NON_DUP_MARKER);
+        s.write::<u8>(0u8); // is_signer
+        s.write::<u8>(0u8); // is_writable
+        s.write::<u8>(0u8); // is_executable
+        s.write_all(&[0u8, 0, 0, 0]); // padding
+        s.write_all(&[0u8; size_of::<Pubkey>()]); // key
+        s.write_all(&[0u8; size_of::<Pubkey>()]); // owner
+        s.write::<u64>(0u64); // lamports
+        s.write::<u64>(0u64); // data_len
+        debug_assert_eq!(
+            s.current_vaddr().saturating_sub(vm_header_addr),
+            SUBACCOUNT_SLOT_HEADER_SIZE as u64,
+        );
+        // Close the [view + header] region so it lives at
+        // vm_account_view_addr..+(view+header) only.
         s.push_region();
-        subaccount_slots.reserve(MAX_SUBACCOUNT_SLOTS);
-        for _ in 0..MAX_SUBACCOUNT_SLOTS {
-            // Runtime-owned account-view buffer: the program writes its
-            // `AccountInfo` / `SolAccountInfo` here after `sol_load_subaccount`
-            // returns the address. Zero-initialized so the program observes a
-            // clean slate per slot.
-            let vm_account_view_addr = s.current_vaddr();
-            s.fill_write(SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE, 0)
-                .map_err(|_| InstructionError::InvalidArgument)?;
-            let vm_header_addr = s.current_vaddr();
-            let buffer_position = s.current_len();
-            s.write::<u8>(NON_DUP_MARKER);
-            s.write::<u8>(0u8); // is_signer
-            s.write::<u8>(0u8); // is_writable
-            s.write::<u8>(0u8); // is_executable
-            s.write_all(&[0u8, 0, 0, 0]); // padding
-            s.write_all(&[0u8; size_of::<Pubkey>()]); // key
-            s.write_all(&[0u8; size_of::<Pubkey>()]); // owner
-            s.write::<u64>(0u64); // lamports
-            s.write::<u64>(0u64); // data_len
-            debug_assert_eq!(
-                s.current_vaddr().saturating_sub(vm_header_addr),
-                SUBACCOUNT_SLOT_HEADER_SIZE as u64,
-            );
-            // Close the [view + header] region so it lives at
-            // vm_account_view_addr..+(view+header) only.
-            s.push_region();
-            // Reserve the slot's data VM address space behind an empty readonly
-            // region; `sol_load_subaccount` swaps this for a writable region.
-            let vm_data_addr = s.current_vaddr();
-            s.push_data_placeholder(SUBACCOUNT_SLOT_DATA_RESERVED_VM_BYTES);
-            subaccount_slots.push(SubaccountSlot {
-                buffer_position,
-                vm_account_view_addr,
-                vm_header_addr,
-                vm_data_addr,
-                caller_account_metadata: None,
-                account_view_kind: None,
-                occupied_subaccount_index: OccupiedSubaccountIndex::Empty,
-                is_writable: false,
-            });
-        }
+        // Reserve the slot's data VM address space behind an empty readonly
+        // region; `sol_load_subaccount` swaps this for a writable region.
+        let vm_data_addr = s.current_vaddr();
+        s.push_data_placeholder(SUBACCOUNT_SLOT_DATA_RESERVED_VM_BYTES);
+        subaccount_slots.push(SubaccountSlot {
+            buffer_position,
+            vm_account_view_addr,
+            vm_header_addr,
+            vm_data_addr,
+            caller_account_metadata: None,
+            account_view_kind: None,
+            occupied_subaccount_index: OccupiedSubaccountIndex::Empty,
+            is_writable: false,
+        });
     }
 
     let (mem, regions) = s.finish();

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -632,24 +632,19 @@ fn serialize_parameters_for_abiv1(
     }
     size += size_of::<u64>() // data len
     + instruction_data.len()
-    + size_of::<Pubkey>() // program id
-    // F10: alignment padding so the u64 subaccount count lands on BPF_ALIGN_OF_U128
-    // boundary, matching parasol-dev PRS-153 layout.
-    + (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
+    + size_of::<Pubkey>(); // program id
+    size += (size as *const u8).align_offset(BPF_ALIGN_OF_U128);
 
     // reserve space for account pointer array if SIMD-0449 is enabled
     if direct_account_pointers_program_input {
         size += accounts.len() * size_of::<u64>();
     };
 
-    // F10 (SIMD-0449 mutual-gate): when direct account pointers are NOT
-    // active, reserve the subaccount slot region in the same post-program_id
-    // byte range the pointer array would occupy. The two are mutually
-    // exclusive by construction — `sol_load_subaccount` is gated off whenever
-    // SIMD-0449 is active — so they never collide. In the direct-map model no
-    // real-subaccount records are serialized (data is direct-mapped); only the
-    // MAX_SUBACCOUNT_SLOTS reserved slots (each an account-view buffer + the
-    // 88-byte header) are laid out, after alignment padding.
+    // F10: reserve the subaccount slot region after the program_id (and, when enabled,
+    // the SIMD-0449 account pointer array). `sol_load_subaccount` is gated off whenever
+    // SIMD-0449 is active, so these reserved slots remain unused in that mode.
+    // In the direct-map model no real-subaccount records are serialized (data is direct-mapped);
+    // only MAX_SUBACCOUNT_SLOTS reserved slots (account-view buffer + 88-byte header) are laid out.
     size += MAX_SUBACCOUNT_SLOTS.saturating_mul(
         SUBACCOUNT_ACCOUNT_VIEW_RESERVED_SIZE.saturating_add(SUBACCOUNT_SLOT_HEADER_SIZE),
     );
@@ -699,7 +694,8 @@ fn serialize_parameters_for_abiv1(
     s.write::<u64>((instruction_data.len() as u64).to_le());
     let instruction_data_offset = s.write_all(instruction_data);
     s.write_all(program_id.as_ref());
-    let align_offset = (instruction_data.len() as *const u8).align_offset(BPF_ALIGN_OF_U128);
+
+    let align_offset = (s.current_vaddr() as *const u8).align_offset(BPF_ALIGN_OF_U128);
     s.fill_write(align_offset, 0)
         .map_err(|_| InstructionError::InvalidArgument)?;
 

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1033,7 +1033,7 @@ mod tests {
                     continue;
                 }
 
-                let (mut serialized, regions, _account_lengths, _instruction_data_offset) =
+                let (mut serialized, regions, _account_lengths, _subaccount_slots, _instruction_data_offset) =
                     serialization_result.unwrap();
                 let mut serialized_regions = concat_regions(&regions);
                 let (de_program_id, de_accounts, de_instruction_data) = unsafe {
@@ -1180,7 +1180,7 @@ mod tests {
                 .unwrap();
 
             // check serialize_parameters_for_abiv1
-            let (mut serialized, regions, accounts_metadata, _instruction_data_offset) =
+            let (mut serialized, regions, accounts_metadata, _subaccount_slots, _instruction_data_offset) =
                 serialize_parameters(
                     &instruction_context,
                     virtual_address_space_adjustments,
@@ -1280,7 +1280,7 @@ mod tests {
                 .get_current_instruction_context()
                 .unwrap();
 
-            let (mut serialized, regions, account_lengths, _instruction_data_offset) =
+            let (mut serialized, regions, account_lengths, _subaccount_slots, _instruction_data_offset) =
                 serialize_parameters(
                     &instruction_context,
                     virtual_address_space_adjustments,
@@ -1445,7 +1445,7 @@ mod tests {
             .unwrap();
 
         // check serialize_parameters_for_abiv1
-        let (_serialized, regions, _accounts_metadata, _instruction_data_offset) =
+        let (_serialized, regions, _accounts_metadata, _subaccount_slots, _instruction_data_offset) =
             serialize_parameters(
                 &instruction_context,
                 true,
@@ -1478,7 +1478,7 @@ mod tests {
             .get_current_instruction_context()
             .unwrap();
 
-        let (_serialized, regions, _account_lengths, _instruction_data_offset) =
+        let (_serialized, regions, _account_lengths, _subaccount_slots, _instruction_data_offset) =
             serialize_parameters(
                 &instruction_context,
                 true,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -113,7 +113,7 @@ mod tests {
         },
         solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message},
         solana_signer::Signer,
-        solana_svm_callback::InvokeContextCallback,
+        solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
         solana_svm_feature_set::SVMFeatureSet,
         solana_transaction_context::transaction::TransactionContext,
         std::{collections::HashSet, sync::Arc},
@@ -121,6 +121,14 @@ mod tests {
 
     struct MockCallback {}
     impl InvokeContextCallback for MockCallback {}
+    impl TransactionProcessingCallback for MockCallback {
+        fn get_account_shared_data(
+            &self,
+            _pubkey: &Pubkey,
+        ) -> Option<(AccountSharedData, solana_clock::Slot)> {
+            None
+        }
+    }
 
     fn create_loadable_account_for_test(name: &str) -> AccountSharedData {
         let (lamports, rent_epoch) = DUMMY_INHERITABLE_ACCOUNT_FIELDS;
@@ -704,6 +712,14 @@ mod tests {
                 } else {
                     Err(PrecompileError::InvalidPublicKey)
                 }
+            }
+        }
+        impl TransactionProcessingCallback for MockCallback {
+            fn get_account_shared_data(
+                &self,
+                _pubkey: &Pubkey,
+            ) -> Option<(AccountSharedData, solana_clock::Slot)> {
+                None
             }
         }
         let feature_set = SVMFeatureSet::all_enabled();

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -3080,7 +3080,17 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(400 - 1);
+        // Each `sol_log` costs max(syscall_base_cost, len). We need `ComputationalBudgetExceeded` on the last call,
+        // so set remaining compute units to 1 less than the total cost of the 4 calls below.
+        let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
+        let string_len = string.len() as u64;
+        invoke_context.mock_set_remaining(
+            syscall_base_cost.max(string_len)
+                + syscall_base_cost.max(string_len * 2)
+                + syscall_base_cost.max(string_len)
+                + syscall_base_cost.max(string_len)
+                - 1,
+        );
         let result = SyscallLog::rust(
             &mut invoke_context,
             0x100000001, // AccessViolation
@@ -3219,6 +3229,8 @@ mod tests {
                 .set_syscall_context(SyscallContext {
                     allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                     accounts_metadata: Vec::new(),
+                    subaccount_slots: Vec::new(),
+                    trace_log: Vec::new(),
                 })
                 .unwrap();
             let config = Config {
@@ -6092,6 +6104,14 @@ mod tests {
             }
             // Vote accounts are not needed for this test.
         }
+        impl solana_svm_callback::TransactionProcessingCallback for MockCallback {
+            fn get_account_shared_data(
+                &self,
+                _pubkey: &Pubkey,
+            ) -> Option<(AccountSharedData, solana_clock::Slot)> {
+                None
+            }
+        }
 
         // Compute units, as specified by SIMD-0133.
         // cu = syscall_base_cost
@@ -6152,6 +6172,14 @@ mod tests {
                 } else {
                     0
                 }
+            }
+        }
+        impl solana_svm_callback::TransactionProcessingCallback for MockCallback {
+            fn get_account_shared_data(
+                &self,
+                _pubkey: &Pubkey,
+            ) -> Option<(AccountSharedData, solana_clock::Slot)> {
+                None
             }
         }
 

--- a/syscalls/src/subaccount.rs
+++ b/syscalls/src/subaccount.rs
@@ -758,6 +758,7 @@ fn sync_subaccount_slot_after_mutation(
                     view_addr,
                     view,
                     &metadata,
+                    true,
                 )?
             }
             AccountViewKind::C => {
@@ -770,6 +771,7 @@ fn sync_subaccount_slot_after_mutation(
                     view_addr,
                     view,
                     &metadata,
+                    true,
                 )?
             }
         };


### PR DESCRIPTION
#### Problem
Porting the subaccounts conflicts with `direct_account_pointers_in_program_input` and `syscall_parameter_address_restrictions` features. This change resolves conflicts.

#### Summary of Changes
1. Reserve subaccounts slots regardless of `direct_account_pointers_in_program_input` status
2. Enable MM_INPUT_REGION for subaccounts inside `CallerAccount::from_account_info()` and `CallerAccount::from_sol_account_info()` because AccountView for SubaccountSlot was placed inside this memory region, and only the core passes these addresses into the function.
