### PR TITLE
PRS-463 Add account_lt_hash to geyser plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,8 @@ dependencies = [
  "log",
  "solana-clock",
  "solana-hash",
+ "solana-lattice-hash",
+ "solana-message",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,6 @@ dependencies = [
  "solana-clock",
  "solana-hash",
  "solana-lattice-hash",
- "solana-message",
  "solana-signature",
  "solana-transaction",
  "solana-transaction-status",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3715,6 +3715,7 @@ impl ReplayStage {
                         bank.executed_transaction_count(),
                         r_replay_progress.num_entries as u64,
                         commission_rate_in_basis_points,
+                        &bank.accounts_lt_hash(),
                     )
                 }
                 bank_complete_time.stop();

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -19,6 +19,8 @@ agave-unstable-api = []
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
+solana-lattice-hash = { workspace = true }
+solana-message = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -20,7 +20,6 @@ log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-lattice-hash = { workspace = true }
-solana-message = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -5,6 +5,8 @@
 use {
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_lattice_hash::lt_hash::LtHash,
+    solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
@@ -288,12 +290,30 @@ pub struct ReplicaBlockInfoV4<'a> {
     pub entry_count: u64,
 }
 
+/// Extending ReplicaBlockInfo by sending the accounts lattice hash.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockInfoV5<'a> {
+    pub parent_slot: Slot,
+    pub parent_blockhash: &'a str,
+    pub slot: Slot,
+    pub blockhash: &'a str,
+    pub rewards: &'a RewardsAndNumPartitions,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub entry_count: u64,
+    /// The lattice hash of all accounts, as of this (frozen) block.
+    pub account_lt_hash: &'a LtHash,
+}
+
 #[repr(u32)]
 pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_1(&'a ReplicaBlockInfo<'a>),
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
     V0_0_4(&'a ReplicaBlockInfoV4<'a>),
+    V0_0_5(&'a ReplicaBlockInfoV5<'a>),
 }
 
 /// Errors returned by plugin calls

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -6,7 +6,6 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
     solana_lattice_hash::lt_hash::LtHash,
-    solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
@@ -304,7 +303,7 @@ pub struct ReplicaBlockInfoV5<'a> {
     pub executed_transaction_count: u64,
     pub entry_count: u64,
     /// The lattice hash of all accounts, as of this (frozen) block.
-    pub account_lt_hash: &'a LtHash,
+    pub accounts_lt_hash: &'a LtHash,
 }
 
 #[repr(u32)]

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -32,7 +32,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         executed_transaction_count: u64,
         entry_count: u64,
         commission_rate_in_basis_points: bool,
-        account_lt_hash: &AccountsLtHash,
+        accounts_lt_hash: &AccountsLtHash,
     ) {
         let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
@@ -50,7 +50,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
-            account_lt_hash,
+            accounts_lt_hash,
         );
 
         for plugin in plugin_manager.plugins.iter() {
@@ -116,7 +116,7 @@ impl BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-        account_lt_hash: &'a AccountsLtHash,
+        accounts_lt_hash: &'a AccountsLtHash,
     ) -> ReplicaBlockInfoV5<'a> {
         ReplicaBlockInfoV5 {
             parent_slot,
@@ -128,7 +128,7 @@ impl BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
-            account_lt_hash: &account_lt_hash.0,
+            accounts_lt_hash: &accounts_lt_hash.0,
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,9 +4,10 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV5, ReplicaBlockInfoVersions,
     },
     log::*,
+    solana_accounts_db::accounts_hash::AccountsLtHash,
     solana_clock::UnixTimestamp,
     solana_runtime::bank::KeyedRewardsAndNumPartitions,
     solana_transaction_status::{Reward, RewardsAndNumPartitions},
@@ -31,6 +32,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         executed_transaction_count: u64,
         entry_count: u64,
         commission_rate_in_basis_points: bool,
+        account_lt_hash: &AccountsLtHash,
     ) {
         let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
@@ -48,10 +50,11 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
+            account_lt_hash,
         );
 
         for plugin in plugin_manager.plugins.iter() {
-            let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
+            let block_info = ReplicaBlockInfoVersions::V0_0_5(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {
                     error!(
@@ -113,8 +116,9 @@ impl BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-    ) -> ReplicaBlockInfoV4<'a> {
-        ReplicaBlockInfoV4 {
+        account_lt_hash: &'a AccountsLtHash,
+    ) -> ReplicaBlockInfoV5<'a> {
+        ReplicaBlockInfoV5 {
             parent_slot,
             parent_blockhash,
             slot,
@@ -124,6 +128,7 @@ impl BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
+            account_lt_hash: &account_lt_hash.0,
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -19,7 +19,7 @@ pub trait BlockMetadataNotifier {
         executed_transaction_count: u64,
         entry_count: u64,
         commission_rate_in_basis_points: bool,
-        account_lt_hash: &AccountsLtHash,
+        accounts_lt_hash: &AccountsLtHash,
     );
 }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,5 +1,6 @@
 use {
-    solana_clock::UnixTimestamp, solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
+    solana_accounts_db::accounts_hash::AccountsLtHash, solana_clock::UnixTimestamp,
+    solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
 };
 
 /// Interface for notifying block metadata changes
@@ -18,6 +19,7 @@ pub trait BlockMetadataNotifier {
         executed_transaction_count: u64,
         entry_count: u64,
         commission_rate_in_basis_points: bool,
+        account_lt_hash: &AccountsLtHash,
     );
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6169,6 +6169,13 @@ impl Bank {
         *self.accounts_lt_hash.lock().unwrap() = accounts_lt_hash;
     }
 
+    /// Returns the lattice hash of all accounts.
+    ///
+    /// The value is only meaningful after the bank is frozen.
+    pub fn accounts_lt_hash(&self) -> AccountsLtHash {
+        self.accounts_lt_hash.lock().unwrap().clone()
+    }
+
     /// Return total transaction fee collected
     pub fn get_collector_fee_details(&self) -> CollectorFeeDetails {
         self.collector_fee_details.read().unwrap().clone()


### PR DESCRIPTION
#### Problem
Solana Geyser plugin interface doesn't contain `accounts_lt_hash` field.

#### Summary of Changes
These changes provide access to the block `accounts_lt_hash` field.
