### PR TITLE
PRS-463 Add account_lt_hash to geyser plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "log",
  "solana-clock",
  "solana-hash 3.1.0",
+ "solana-lattice-hash",
  "solana-message",
  "solana-signature",
  "solana-transaction",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3517,6 +3517,7 @@ impl ReplayStage {
                         Some(bank.block_height()),
                         bank.executed_transaction_count(),
                         r_replay_progress.num_entries as u64,
+                        &bank.accounts_lt_hash(),
                     )
                 }
                 bank_complete_time.stop();

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -19,6 +19,7 @@ agave-unstable-api = []
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
+solana-lattice-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -5,6 +5,7 @@
 use {
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
+    solana_lattice_hash::lt_hash::LtHash,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
@@ -356,12 +357,30 @@ pub struct ReplicaBlockInfoV4<'a> {
     pub entry_count: u64,
 }
 
+/// Extending ReplicaBlockInfo by sending the accounts lattice hash.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockInfoV5<'a> {
+    pub parent_slot: Slot,
+    pub parent_blockhash: &'a str,
+    pub slot: Slot,
+    pub blockhash: &'a str,
+    pub rewards: &'a RewardsAndNumPartitions,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub entry_count: u64,
+    /// The lattice hash of all accounts, as of this (frozen) block.
+    pub accounts_lt_hash: &'a LtHash,
+}
+
 #[repr(u32)]
 pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_1(&'a ReplicaBlockInfo<'a>),
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
     V0_0_4(&'a ReplicaBlockInfoV4<'a>),
+    V0_0_5(&'a ReplicaBlockInfoV5<'a>),
 }
 
 /// Errors returned by plugin calls

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,9 +4,10 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV5, ReplicaBlockInfoVersions,
     },
     log::*,
+    solana_accounts_db::accounts_hash::AccountsLtHash,
     solana_clock::UnixTimestamp,
     solana_measure::measure::Measure,
     solana_metrics::*,
@@ -32,6 +33,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
+        accounts_lt_hash: &AccountsLtHash,
     ) {
         let plugin_manager = self.plugin_manager.read().unwrap();
         if plugin_manager.plugins.is_empty() {
@@ -49,11 +51,12 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
+            accounts_lt_hash,
         );
 
         for plugin in plugin_manager.plugins.iter() {
             let mut measure = Measure::start("geyser-plugin-update-slot");
-            let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
+            let block_info = ReplicaBlockInfoVersions::V0_0_5(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {
                     error!(
@@ -110,8 +113,9 @@ impl BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-    ) -> ReplicaBlockInfoV4<'a> {
-        ReplicaBlockInfoV4 {
+        accounts_lt_hash: &'a AccountsLtHash,
+    ) -> ReplicaBlockInfoV5<'a> {
+        ReplicaBlockInfoV5 {
             parent_slot,
             parent_blockhash,
             slot,
@@ -121,6 +125,7 @@ impl BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
+            accounts_lt_hash: &accounts_lt_hash.0,
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,5 +1,6 @@
 use {
-    solana_clock::UnixTimestamp, solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
+    solana_accounts_db::accounts_hash::AccountsLtHash, solana_clock::UnixTimestamp,
+    solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
 };
 
 /// Interface for notifying block metadata changes
@@ -17,6 +18,7 @@ pub trait BlockMetadataNotifier {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
+        accounts_lt_hash: &AccountsLtHash,
     );
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5830,6 +5830,13 @@ impl Bank {
         *self.accounts_lt_hash.lock().unwrap() = accounts_lt_hash;
     }
 
+    /// Returns the lattice hash of all accounts.
+    ///
+    /// The value is only meaningful after the bank is frozen.
+    pub fn accounts_lt_hash(&self) -> AccountsLtHash {
+        self.accounts_lt_hash.lock().unwrap().clone()
+    }
+
     /// Return total transaction fee collected
     pub fn get_collector_fee_details(&self) -> CollectorFeeDetails {
         self.collector_fee_details.read().unwrap().clone()


### PR DESCRIPTION
#### Problem
Solana Geyser plugin interface doesn't contain `accounts_lt_hash` field.

#### Summary of Changes
Provide access to the block `accounts_lt_hash` field (create a new enum to provide block info)

Notice: these changes break compatibility with the yellow-stone plugin that should be recompiled.
