### PR TITLE
sbf bench: restore SubaccountSlot element in serialize_parameters des…

### DIFF
--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -254,16 +254,17 @@ fn bench_create_vm(bencher: &mut Bencher) {
     executable.verify::<RequisiteVerifier>().unwrap();
 
     // Serialize account data
-    let (_serialized, regions, account_lengths, _instruction_data_offset) = serialize_parameters(
-        &invoke_context
-            .transaction_context
-            .get_current_instruction_context()
-            .unwrap(),
-        virtual_address_space_adjustments,
-        account_data_direct_mapping,
-        direct_account_pointers_in_program_input,
-    )
-    .unwrap();
+    let (_serialized, regions, account_lengths, _subaccount_slots, _instruction_data_offset) =
+        serialize_parameters(
+            &invoke_context
+                .transaction_context
+                .get_current_instruction_context()
+                .unwrap(),
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+            direct_account_pointers_in_program_input,
+        )
+        .unwrap();
 
     bencher.iter(|| {
         create_vm!(
@@ -295,16 +296,17 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .direct_account_pointers_in_program_input;
 
     // Serialize account data
-    let (_serialized, regions, account_lengths, _instruction_data_offset) = serialize_parameters(
-        &invoke_context
-            .transaction_context
-            .get_current_instruction_context()
-            .unwrap(),
-        virtual_address_space_adjustments,
-        account_data_direct_mapping,
-        direct_account_pointers_in_program_input,
-    )
-    .unwrap();
+    let (_serialized, regions, account_lengths, _subaccount_slots, _instruction_data_offset) =
+        serialize_parameters(
+            &invoke_context
+                .transaction_context
+                .get_current_instruction_context()
+                .unwrap(),
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+            direct_account_pointers_in_program_input,
+        )
+        .unwrap();
 
     let feature_set = invoke_context.get_feature_set();
     let program_runtime_environment = create_program_runtime_environment_v1(


### PR DESCRIPTION
Fixes a tuple-arity mismatch (E0023) in `programs/sbf/benches/bpf_loader.rs`.

In the parasol fork, `serialize_parameters` returns a 5-tuple `(AlignedMemory, Vec<MemoryRegion>, Vec<SerializedAccountMetadata>, Vec<SubaccountSlot>, usize)`, but both call sites in the bench destructured only 4 elements, dropping the `Vec<SubaccountSlot>` lane. This breaks `cargo bench` / `--all-targets` builds.

## Why it went unnoticed

The bench is gated behind `#![feature(test)]` + `#![cfg(feature = "sbf_c")]`, so the default validator/test build never compiles it.

## Change

Bind the fourth element as `_subaccount_slots` at both call sites, matching the pattern already used in `program-test/src/lib.rs`. One file, +22/-20, no behavioural change.